### PR TITLE
Stable learned spells and a Magic catalog at the end of the sheet

### DIFF
--- a/AtlasLusoris/Compass_of_Learned_Spells.py
+++ b/AtlasLusoris/Compass_of_Learned_Spells.py
@@ -5,9 +5,24 @@ The sheet ± buttons reuse the same seed. Spell picks must not reshuffle:
 each new level only adds spells. A dedicated RNG (not the main character
 RNG) is used so other random rolls cannot steal the sequence.
 
-Two separate actions:
-- know_spell: the character gains a spell as known. No HTML.
-- html_spell_index / html_spell_catalog: display the spells currently known.
+Three lists, not two:
+- Accessible (`spells_available`): the class list you may learn from,
+  capped by slot level. This is the pool, not a known-spell budget.
+- Class-known (`spells_known`): class-progression picks. These consume
+  the class known / prepared budget.
+- Granted (`granted_spells`): feats, species, invocations, Magician extra
+  cantrips, subclass always-prepared names, and similar. A grant never
+  consumes a class-known slot. If the class already spent a slot on that
+  name, the grant takes ownership and the slot is refilled from accessible.
+
+Public catalog = unique(class-known + granted). Display is a separate action:
+- know_spell / grant_spell: change what the character has. No HTML.
+- html_spell_index / html_spell_catalog: show the current catalog.
+
+When a feature grants a spell, skip it if it is already granted; if it is
+only class-known, move it to granted and pick a new accessible name so the
+class budget is not wasted. Pickers (Magician, Magic Initiate, Savant,
+Druidic Warrior) should skip names already in the catalog.
 
 progressive_learn is the lifetime sequence computed on the fly: same seed,
 walk levels 1..N, only add. The sheet shows what this level has unlocked.
@@ -110,15 +125,19 @@ def progressive_learn(
 		slots_at,
 		salt=1,
 		always=None,
+		skip=None,
 		):
 	"""
 	Walk levels 1..level. At each step, only add the newly granted
 	cantrips and leveled spells. Prefer the newly unlocked slot level.
+
+	`skip` is names already owned (granted or otherwise). They are not
+	added to the returned lists and do not consume a pick.
 	"""
 	rng = caster_rng(character, salt)
 	cantrips = []
 	known = []
-	already = set()
+	already = {str(name).strip() for name in (skip or []) if str(name).strip()}
 	for spell in unique_spells(always):
 		if spell_level(spell) == 0:
 			cantrips.append(spell)
@@ -202,8 +221,76 @@ def spell_book(character):
 	return book
 
 
+def catalog_keys(caster):
+	if caster is None:
+		return set()
+	return {spell_key(spell) for spell in catalog_spells(caster)}
+
+
+def accessible_spells(caster):
+	"""Class list the character may learn from. Not the known budget."""
+	if caster is None:
+		return []
+	pool = getattr(caster, "spells_available", None)
+	if pool:
+		return unique_spells(pool)
+	available = getattr(caster, "available_spells", None)
+	if callable(available):
+		return unique_spells(available())
+	return []
+
+
+def fill_class_known_slot(character, book, vacated_level, was_prepared=False):
+	"""Spend a freed class-known slot on a new accessible spell."""
+	if book is None:
+		return None
+	already = catalog_keys(book)
+	pool = accessible_spells(book)
+	if vacated_level == 0:
+		pool = [spell for spell in pool if spell_level(spell) == 0]
+	else:
+		same = [spell for spell in pool if spell_level(spell) == vacated_level]
+		leveled = [spell for spell in pool if spell_level(spell) >= 1]
+		pool = same or leveled
+	if not pool:
+		return None
+	n = getattr(book, "_known_reclaims", 0)
+	book._known_reclaims = n + 1
+	added = pick_new(pool, 1, caster_rng(character, 0xF11 ^ n), already)
+	if not added:
+		return None
+	replacement = added[0]
+	book.spells_known = unique_spells(list(book.spells_known) + [replacement])
+	if was_prepared:
+		prepared = list(getattr(book, "prepared_spells", []) or [])
+		prepared.append(replacement)
+		book.prepared_spells = unique_spells(prepared)
+	return replacement
+
+
+def _take_from_class_known(book, key):
+	"""Remove a class-known pick so a grant can own that name instead."""
+	vacated_level = 0
+	found = False
+	remaining = []
+	for spell in list(getattr(book, "spells_known", []) or []):
+		if not found and spell_key(spell) == key:
+			found = True
+			vacated_level = spell_level(spell)
+			continue
+		remaining.append(spell)
+	if not found:
+		return None, False
+	book.spells_known = remaining
+	prepared = list(getattr(book, "prepared_spells", []) or [])
+	was_prepared = any(spell_key(spell) == key for spell in prepared)
+	if was_prepared:
+		book.prepared_spells = [spell for spell in prepared if spell_key(spell) != key]
+	return vacated_level, was_prepared
+
+
 def know_spell(character, spell, always_prepared=True):
-	"""Gain a spell as known. Display is a separate action (html_spell_catalog)."""
+	"""Grant a spell without consuming a class-known slot. Display is separate."""
 	if spell is None or character is None:
 		return
 	book = spell_book(character)
@@ -213,12 +300,28 @@ def know_spell(character, spell, always_prepared=True):
 		book.granted_spells = []
 	if getattr(book, "always_prepared", None) is None:
 		book.always_prepared = set()
+	if getattr(book, "spells_known", None) is None:
+		book.spells_known = []
 	key = spell_key(spell)
 	if not key:
 		return
-	have = {spell_key(item) for item in catalog_spells(book)}
-	if key not in have:
+	granted = {spell_key(item) for item in book.granted_spells}
+	if key in granted:
+		if always_prepared:
+			book.always_prepared.add(key)
+		return
+	known = {spell_key(item) for item in book.spells_known}
+	if key in known:
+		vacated_level, was_prepared = _take_from_class_known(book, key)
 		book.granted_spells.append(spell)
+		if always_prepared:
+			book.always_prepared.add(key)
+		if vacated_level is not None:
+			fill_class_known_slot(
+				character, book, vacated_level, was_prepared=was_prepared,
+				)
+		return
+	book.granted_spells.append(spell)
 	if always_prepared:
 		book.always_prepared.add(key)
 
@@ -285,6 +388,7 @@ def pick_magic_initiate(character, list_name):
 	table = SPELL_LISTS.get(list_name) or {}
 	if not any(table.values()):
 		table = SPELL_LISTS.get("Wizard", {})
+	already = catalog_keys(getattr(character, "spellcaster", None))
 	cantrips, leveled = progressive_learn(
 		character,
 		table,
@@ -293,6 +397,7 @@ def pick_magic_initiate(character, list_name):
 		known_at=lambda lvl: 1,
 		slots_at=lambda lvl: (1,),
 		salt=0x1A1 ^ CLASS_SALT.get(list_name, 0),
+		skip=already,
 		)
 	return unique_spells(cantrips + leveled)
 

--- a/AtlasLusoris/Compass_of_Learned_Spells.py
+++ b/AtlasLusoris/Compass_of_Learned_Spells.py
@@ -4,6 +4,15 @@ Learned spells stay put as a character levels up.
 The sheet ± buttons reuse the same seed. Spell picks must not reshuffle:
 each new level only adds spells. A dedicated RNG (not the main character
 RNG) is used so other random rolls cannot steal the sequence.
+
+Two separate actions:
+- know_spell: the character gains a spell as known. No HTML.
+- html_spell_index / html_spell_catalog: display the spells currently known.
+
+progressive_learn is the lifetime sequence computed on the fly: same seed,
+walk levels 1..N, only add. The sheet shows what this level has unlocked.
+A stored 1–20 shadow list is not needed unless we want to preview future
+spells on the sheet.
 """
 import random as stdlib_random
 
@@ -156,25 +165,67 @@ def finish_learning(caster, cantrips, known, prepared_count=None):
 	return caster.spells_known
 
 
-def grant_spell(character, spell, always_prepared=True):
-	"""Attach a feature-granted spell to the sheet catalog. Does not replace learned spells."""
+class KnownSpellBook:
+	"""Holds spells a character knows when the class is not a caster."""
+
+	def __init__(self, character):
+		self.character = character
+		self.level = getattr(character, "level", 1)
+		self.spells_known = []
+		self.granted_spells = []
+		self.always_prepared = set()
+		self.prepared_spells = []
+		self.catalog_known = True
+
+	def html(self):
+		index = html_spell_index(self)
+		if not index:
+			return ""
+		return f"""<div class="npc-textbox" style="grid-column: span 1;">
+			<h3 style="font-family: 'Iglesia'; font-size: 3.1em;">Spell List</h3>
+			{index}
+			</div>"""
+
+	def html_catalog(self):
+		return html_spell_catalog(self)
+
+
+def spell_book(character):
+	"""The book that holds spells this character currently knows."""
+	if character is None:
+		return None
+	book = getattr(character, "spellcaster", None)
+	if book is not None:
+		return book
+	book = KnownSpellBook(character)
+	character.spellcaster = book
+	return book
+
+
+def know_spell(character, spell, always_prepared=True):
+	"""Gain a spell as known. Display is a separate action (html_spell_catalog)."""
 	if spell is None or character is None:
 		return
-	caster = getattr(character, "spellcaster", None)
-	if caster is None:
+	book = spell_book(character)
+	if book is None:
 		return
-	if getattr(caster, "granted_spells", None) is None:
-		caster.granted_spells = []
-	if getattr(caster, "always_prepared", None) is None:
-		caster.always_prepared = set()
+	if getattr(book, "granted_spells", None) is None:
+		book.granted_spells = []
+	if getattr(book, "always_prepared", None) is None:
+		book.always_prepared = set()
 	key = spell_key(spell)
 	if not key:
 		return
-	have = {spell_key(item) for item in catalog_spells(caster)}
+	have = {spell_key(item) for item in catalog_spells(book)}
 	if key not in have:
-		caster.granted_spells.append(spell)
+		book.granted_spells.append(spell)
 	if always_prepared:
-		caster.always_prepared.add(key)
+		book.always_prepared.add(key)
+
+
+def grant_spell(character, spell, always_prepared=True):
+	"""Older name for know_spell. Still does not display."""
+	return know_spell(character, spell, always_prepared=always_prepared)
 
 
 def catalog_spells(caster):

--- a/AtlasLusoris/Compass_of_Learned_Spells.py
+++ b/AtlasLusoris/Compass_of_Learned_Spells.py
@@ -1,0 +1,250 @@
+"""
+Learned spells stay put as a character levels up.
+
+The sheet ± buttons reuse the same seed. Spell picks must not reshuffle:
+each new level only adds spells. A dedicated RNG (not the main character
+RNG) is used so other random rolls cannot steal the sequence.
+"""
+import random as stdlib_random
+
+CLASS_SALT = {
+	"Wizard": 1,
+	"Druid": 2,
+	"Ranger": 3,
+	"Sorcerer": 4,
+	"Warlock": 5,
+	"Eldritch Knight": 6,
+	"Arcane Trickster": 7,
+	"Paladin": 8,
+	"Bard": 9,
+	"Cleric": 10,
+	"Monk": 11,
+	}
+
+
+def spell_level(spell):
+	try:
+		return int(getattr(spell, "level", 0) or 0)
+	except (TypeError, ValueError):
+		return 0
+
+
+def spell_key(spell):
+	return str(getattr(spell, "name", "")).strip()
+
+
+def unique_spells(spells):
+	seen = set()
+	out = []
+	for spell in spells or []:
+		if spell is None:
+			continue
+		key = spell_key(spell)
+		if not key or key in seen:
+			continue
+		seen.add(key)
+		out.append(spell)
+	return out
+
+
+def spell_mark(spell, prepared=True):
+	level = spell_level(spell)
+	name = spell_key(spell)
+	if prepared:
+		return f"【{level}】{name}"
+	return f"〖{level}〗{name}"
+
+
+def caster_rng(character, salt=0):
+	try:
+		seed = int(getattr(character, "seed", 0) or 0)
+	except (TypeError, ValueError):
+		seed = 0
+	return stdlib_random.Random((seed << 16) ^ int(salt))
+
+
+def pick_new(pool, n, rng, already):
+	candidates = [
+		spell for spell in unique_spells(pool)
+		if spell_key(spell) not in already
+		]
+	rng.shuffle(candidates)
+	return candidates[:max(0, n)]
+
+
+def max_slot_from(slots):
+	if isinstance(slots, dict):
+		levels = [lvl for lvl, n in slots.items() if n]
+		return max(levels) if levels else 0
+	if isinstance(slots, (tuple, list)):
+		levels = [i + 1 for i, n in enumerate(slots) if n]
+		return max(levels) if levels else 0
+	return 0
+
+
+def stats_at_level(caster, lvl, key):
+	"""Read a caster table row for a walked level without leaving the live level changed."""
+	previous = getattr(caster, "level", 1)
+	caster.level = min(max(int(lvl), 1), 20)
+	try:
+		return caster.get_stats(key)
+	finally:
+		caster.level = previous
+
+
+def progressive_learn(
+		character,
+		table,
+		level,
+		cantrips_at,
+		known_at,
+		slots_at,
+		salt=1,
+		always=None,
+		):
+	"""
+	Walk levels 1..level. At each step, only add the newly granted
+	cantrips and leveled spells. Prefer the newly unlocked slot level.
+	"""
+	rng = caster_rng(character, salt)
+	cantrips = []
+	known = []
+	already = set()
+	for spell in unique_spells(always):
+		if spell_level(spell) == 0:
+			cantrips.append(spell)
+		else:
+			known.append(spell)
+		already.add(spell_key(spell))
+	table = table or {}
+	for lvl in range(1, max(1, int(level)) + 1):
+		n_cantrips = cantrips_at(lvl)
+		n_known = known_at(lvl)
+		max_slot = max_slot_from(slots_at(lvl))
+		if n_cantrips > len(cantrips):
+			added = pick_new(table.get(0, []), n_cantrips - len(cantrips), rng, already)
+			cantrips.extend(added)
+			already.update(spell_key(spell) for spell in added)
+		if n_known > len(known):
+			need = n_known - len(known)
+			added = []
+			if max_slot >= 1:
+				added = pick_new(table.get(max_slot, []), need, rng, already)
+			if len(added) < need:
+				pool = []
+				for slot in range(1, max_slot + 1):
+					pool.extend(table.get(slot, []))
+				added.extend(pick_new(pool, need - len(added), rng, already))
+			known.extend(added)
+			already.update(spell_key(spell) for spell in added)
+	return cantrips, known
+
+
+def finish_learning(caster, cantrips, known, prepared_count=None):
+	"""Store a growing known list. Prepared is a stable prefix, never reshuffled."""
+	if getattr(caster, "granted_spells", None) is None:
+		caster.granted_spells = []
+	if getattr(caster, "always_prepared", None) is None:
+		caster.always_prepared = set()
+	cantrips = unique_spells(cantrips)
+	known = unique_spells(known)
+	caster.spells_known = unique_spells(list(cantrips) + list(known))
+	if prepared_count is None:
+		caster.prepared_spells = list(caster.spells_known)
+	else:
+		caster.prepared_spells = unique_spells(list(cantrips) + list(known)[:max(0, int(prepared_count))])
+	return caster.spells_known
+
+
+def grant_spell(character, spell, always_prepared=True):
+	"""Attach a feature-granted spell to the sheet catalog. Does not replace learned spells."""
+	if spell is None or character is None:
+		return
+	caster = getattr(character, "spellcaster", None)
+	if caster is None:
+		return
+	if getattr(caster, "granted_spells", None) is None:
+		caster.granted_spells = []
+	if getattr(caster, "always_prepared", None) is None:
+		caster.always_prepared = set()
+	key = spell_key(spell)
+	if not key:
+		return
+	have = {spell_key(item) for item in catalog_spells(caster)}
+	if key not in have:
+		caster.granted_spells.append(spell)
+	if always_prepared:
+		caster.always_prepared.add(key)
+
+
+def catalog_spells(caster):
+	granted = list(getattr(caster, "granted_spells", []) or [])
+	if getattr(caster, "catalog_known", True):
+		known = list(getattr(caster, "spells_known", []) or [])
+		return unique_spells(known + granted)
+	return unique_spells(granted)
+
+
+def prepared_keys(caster):
+	prepared = getattr(caster, "prepared_spells", None)
+	if prepared is None:
+		keys = {spell_key(spell) for spell in getattr(caster, "spells_known", []) or []}
+	else:
+		keys = {spell_key(spell) for spell in prepared}
+	keys |= set(getattr(caster, "always_prepared", set()) or [])
+	return keys
+
+
+def html_spell_index(caster, bullet="🪄"):
+	spells = catalog_spells(caster)
+	spells.sort(key=lambda spell: (spell_level(spell), spell_key(spell)))
+	prepared = prepared_keys(caster)
+	items = []
+	for spell in spells:
+		is_prepared = spell_key(spell) in prepared or spell_level(spell) == 0
+		items.append(f"<li>{spell_mark(spell, prepared=is_prepared)}</li>")
+	if not items:
+		return ""
+	return f"""<ul style="list-style-type: '{bullet}'; text-align: left; font-family: 'Iglesia'">{"".join(items)}</ul>"""
+
+
+def html_spell_catalog(caster):
+	"""Full writeups, one block each, at the end of the sheet."""
+	spells = catalog_spells(caster)
+	spells.sort(key=lambda spell: (spell_level(spell), spell_key(spell)))
+	if not spells:
+		return ""
+	prepared = prepared_keys(caster)
+	blocks = [
+		"""<div class="npc-textbox" style="grid-column: 1 / -1;">
+			<h1 style="font-family: 'Iglesia'; font-size: 2.4em;">Spells</h1>
+			<p>【prepared / always available】 &nbsp; 〖written or granted, not prepared】</p>
+			</div>"""
+		]
+	for spell in spells:
+		is_prepared = spell_key(spell) in prepared or spell_level(spell) == 0
+		blocks.append(
+			f"""<div class="npc-textbox">{spell_mark(spell, prepared=is_prepared)}<br>{spell}</div>"""
+			)
+	return "".join(blocks)
+
+
+def pick_magic_initiate(character, list_name):
+	from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
+	table = SPELL_LISTS.get(list_name) or {}
+	if not any(table.values()):
+		table = SPELL_LISTS.get("Wizard", {})
+	cantrips, leveled = progressive_learn(
+		character,
+		table,
+		level=1,
+		cantrips_at=lambda lvl: 2,
+		known_at=lambda lvl: 1,
+		slots_at=lambda lvl: (1,),
+		salt=0x1A1 ^ CLASS_SALT.get(list_name, 0),
+		)
+	return unique_spells(cantrips + leveled)
+
+
+def names_line(spells, prepared=True):
+	return ", ".join(spell_mark(spell, prepared=prepared) for spell in unique_spells(spells))

--- a/AtlasLusoris/Compass_of_Learned_Spells.py
+++ b/AtlasLusoris/Compass_of_Learned_Spells.py
@@ -72,11 +72,24 @@ def unique_spells(spells):
 
 
 def spell_mark(spell, prepared=True):
-	level = spell_level(spell)
+	"""Spell name in the sheet hand. Prepared state lives on the chip, not in brackets."""
 	name = spell_key(spell)
-	if prepared:
-		return f"【{level}】{name}"
-	return f"〖{level}〗{name}"
+	kind = "prepared" if prepared else "written"
+	return f"<span class='spell-name spell-{kind}'>{name}</span>"
+
+
+LEVEL_LABELS = {
+	0: "Cantrips",
+	1: "Level 1",
+	2: "Level 2",
+	3: "Level 3",
+	4: "Level 4",
+	5: "Level 5",
+	6: "Level 6",
+	7: "Level 7",
+	8: "Level 8",
+	9: "Level 9",
+	}
 
 
 def caster_rng(character, salt=0):
@@ -352,14 +365,28 @@ def prepared_keys(caster):
 def html_spell_index(caster, bullet="🪄"):
 	spells = catalog_spells(caster)
 	spells.sort(key=lambda spell: (spell_level(spell), spell_key(spell)))
-	prepared = prepared_keys(caster)
-	items = []
-	for spell in spells:
-		is_prepared = spell_key(spell) in prepared or spell_level(spell) == 0
-		items.append(f"<li>{spell_mark(spell, prepared=is_prepared)}</li>")
-	if not items:
+	if not spells:
 		return ""
-	return f"""<ul style="list-style-type: '{bullet}'; text-align: left; font-family: 'Iglesia'">{"".join(items)}</ul>"""
+	prepared = prepared_keys(caster)
+	groups = {}
+	for spell in spells:
+		groups.setdefault(spell_level(spell), []).append(spell)
+	blocks = ['<div class="spell-chip-rail">']
+	for level in sorted(groups):
+		label = LEVEL_LABELS.get(level, f"Level {level}")
+		chips = []
+		for spell in groups[level]:
+			is_prepared = spell_key(spell) in prepared or level == 0
+			kind = "prepared" if is_prepared else "written"
+			chips.append(
+				f"<span class='spell-chip spell-{kind}'>{spell_key(spell)}</span>"
+				)
+		blocks.append(
+			f"<div class='spell-chip-group'><span class='spell-chip-level'>{label}</span>"
+			f"<div class='spell-chip-row'>{''.join(chips)}</div></div>"
+			)
+	blocks.append("</div>")
+	return "".join(blocks)
 
 
 def html_spell_catalog(caster):
@@ -372,7 +399,6 @@ def html_spell_catalog(caster):
 	blocks = [
 		"""<div class="npc-textbox" style="grid-column: 1 / -1;">
 			<h1 style="font-family: 'Iglesia'; font-size: 2.4em;">Spells</h1>
-			<p>【prepared / always available】 &nbsp; 〖written or granted, not prepared】</p>
 			</div>"""
 		]
 	for spell in spells:
@@ -384,10 +410,8 @@ def html_spell_catalog(caster):
 
 
 def pick_magic_initiate(character, list_name):
-	from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
-	table = SPELL_LISTS.get(list_name) or {}
-	if not any(table.values()):
-		table = SPELL_LISTS.get("Wizard", {})
+	from AtlasLusoris.Grimoire_of_Spellcasters import class_spell_table
+	table = class_spell_table(list_name)
 	already = catalog_keys(getattr(character, "spellcaster", None))
 	cantrips, leveled = progressive_learn(
 		character,

--- a/AtlasLusoris/Grimoire_of_Characters.py
+++ b/AtlasLusoris/Grimoire_of_Characters.py
@@ -399,6 +399,7 @@ class Character:
 			'Scribe':     ['Dexterity', 	'Wisdom', 		'Intelligence'],
 			'Soldier':    ['Strength', 		'Dexterity', 	'Constitution'],
 			'Wayfarer':   ['Dexterity', 	'Charisma', 	'Wisdom'],
+			'Wildkeeper': ['Constitution', 	'Intelligence', 'Wisdom'],
 			}
 
 		# Initialize stats dictionary
@@ -559,6 +560,10 @@ class Character:
 				char.skills.Insight.set_proficiency()
 				char.skills.Stealth.set_proficiency()
 				char.skills.Thieves_Tools.set_proficiency()
+			elif char.background == "Wildkeeper":
+				char.skills.Nature.set_proficiency()
+				char.skills.Survival.set_proficiency()
+				char.skills.Herbalism_Kit.set_proficiency()
 
 		# Step 3: Adjust skills based on subclass (if any)
 		if char.subclass:

--- a/AtlasLusoris/Grimoire_of_Characters.py
+++ b/AtlasLusoris/Grimoire_of_Characters.py
@@ -138,7 +138,7 @@ class Character:
 
 	@property
 	def passive_perception(char):
-		Mod = char.skills.Perception.calculate_modifier()
+		Mod = char.skills.Perception.calculate_modifier(char.proficiency_bonus)
 		return 10 + Mod
 
 	def SetFeatures(char):
@@ -566,7 +566,14 @@ class Character:
 				char.skills.Arcana.set_proficiency()
 			elif char.subclass == "Battlemaster":
 				char.skills.Intimidation.set_proficiency()
-			# Add more subclasses
+			elif char.subclass in ("Diviner", "Divination"):
+				char.skills.Insight.set_proficiency()
+			elif char.subclass in ("Necromancer", "Necromancy"):
+				char.skills.Religion.set_proficiency()
+			elif char.subclass in ("Illusionist", "Illusion"):
+				char.skills.Deception.set_proficiency()
+			elif char.subclass in ("Abjurer", "Abjuration", "Evoker", "Evocation"):
+				char.skills.Arcana.set_proficiency()
 
 		# Step 2: Set default skills based on class
 		if char.character_class:

--- a/AtlasLusoris/Grimoire_of_Features.py
+++ b/AtlasLusoris/Grimoire_of_Features.py
@@ -1407,6 +1407,48 @@ def SavageAttacker():
 		level=1,
 		)
 
+def origin_spell_stat(char):
+	"""A starting voice for origin-feat spells. The player can pick INT, WIS, or CHA."""
+	cls = str(getattr(char, "char_class", "") or "")
+	if any(name in cls for name in ("Wizard", "Eldritch Knight")):
+		return "INT"
+	if any(name in cls for name in ("Bard", "Sorcerer", "Warlock", "Paladin")):
+		return "CHA"
+	return "WIS"
+
+def Wildwarden():
+	"""
+	Origin feat for the Wildkeeper background.
+	Speak with Animals is gained as known; the writeup lives in Spells.
+	"""
+	feat = Feat(
+		name="Wildwarden",
+		apply=lambda char: None,
+		description=(
+			"You always have Speak with Animals prepared, and you can cast it with any spell slots you have. "
+			"When you cast it as a Ritual, the duration is 8 hours. "
+			"When you take the Help action, you can switch places with a willing ally within 5 feet."
+		),
+		source="Background Feat",
+		level=1,
+	)
+	def apply(char):
+		from AtlasMagia.Lodge_of_Spells import SpeakwithAnimals
+		from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+		stat = origin_spell_stat(char)
+		know_spell(char, SpeakwithAnimals)
+		feat.description = (
+			f"You always have {spell_mark(SpeakwithAnimals)} prepared. "
+			f"You can cast it with any spell slots you have. {stat} is your spellcasting ability for it "
+			"(you may choose Intelligence, Wisdom, or Charisma instead). "
+			"When you cast it as a Ritual, the duration is 8 hours. See Spells."
+			"<br><b>Tag Team.</b> When you take the Help action, you can switch places with a willing ally "
+			"within 5 feet as part of that action. This movement doesn't provoke Opportunity Attacks. "
+			"You can't use this if the ally is Incapacitated."
+			)
+	feat.apply = apply
+	return feat
+
 def Resourceful():
 	"""
 	PHB 2024 p. 35.  You always wake up with Heroic Inspiration and can use

--- a/AtlasLusoris/Grimoire_of_Features.py
+++ b/AtlasLusoris/Grimoire_of_Features.py
@@ -668,26 +668,6 @@ def Fighting_Styles(char=None):
 			)
 		if char.level >= 18: styles.pop("Blind Fighting", None)
 	return styles
-	if char and "Ranger" in char:
-		print("ENTER RANGER DRUIDIC WARRIOR")
-
-		druid_cantrips: list[Spell] = SPELL_LISTS["Druid"][0][:]
-		chosen: list[Spell] = random.sample(druid_cantrips, 2)
-
-		if hasattr(char, "spells_known"):
-			for sp in chosen:
-				if sp not in char.spells_known:
-					char.spells_known.append(sp)
-
-		# Build pretty HTML blocks for the sheet
-		html_blocks = "".join(f"<div class='npc-textbox'>{sp}</div>" for sp in chosen)
-
-		result["Druidic Warrior"] = (
-			"You learn two druid cantrips (shown below). They count as Ranger "
-			"spells for you, and Wisdom is your spell-casting ability for them."
-			f"{html_blocks}"
-		)
-	return result
 
 def character_fighting_styles(char):
 	"""Return a set of fighting style names the character already has."""
@@ -1130,46 +1110,31 @@ def GnomishCunning():
 		)
 
 def ForestGnomeLineage():
+	from AtlasMagia.Lodge_of_Spells import MinorIllusion, SpeakwithAnimals
+	from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+
 	def apply(char):
-		from AtlasMagia.Lodge_of_Spells import MinorIllusion, SpeakwithAnimals
-		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
-		if not hasattr(char, "cantrips"):
-			char.cantrips = []
-		if not hasattr(char, "spells_known"):
-			char.spells_known = []
-		char.cantrips.append({
-			"name": "Minor Illusion",
-			"casting_stat": "INT",
-			"source": "Species Feature"
-		})
-		char.spells_known.append({
-			"name": "Speak with Animals",
-			"casting_stat": "INT",
-			"uses_per_day": char.proficiency_bonus,
-			"source": "Species Feature"
-		})
-		grant_spell(char, MinorIllusion)
-		grant_spell(char, SpeakwithAnimals)
+		know_spell(char, MinorIllusion)
+		know_spell(char, SpeakwithAnimals)
 
 	return Feature(
 		name="Forest Gnome Lineage",
 		apply=apply,
-		description="You know 【0】Minor Illusion. You can cast 【1】Speak with Animals a number of times per long rest equal to your proficiency bonus. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell. See Spells.",
+		description=(
+			f"You know {spell_mark(MinorIllusion)}. "
+			f"You can cast {spell_mark(SpeakwithAnimals)} a number of times equal to your Proficiency Bonus without a spell slot (Long Rest), "
+			"and you can also spend spell slots to cast it. Intelligence is your spellcasting ability. See Spells."
+			),
 		source="Species Lineage"
 	)
 
 def RockGnomeLineage():
+	from AtlasMagia.Lodge_of_Spells import Mending, Prestidigitation
+	from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+
 	def apply(char):
-		from AtlasMagia.Lodge_of_Spells import Mending, Prestidigitation
-		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
-		if not hasattr(char, "cantrips"):
-			char.cantrips = []
-		char.cantrips.extend([
-			{"name": "Mending", "casting_stat": "INT", "source": "Species Feature"},
-			{"name": "Prestidigitation", "casting_stat": "INT", "source": "Species Feature"}
-		])
-		grant_spell(char, Mending)
-		grant_spell(char, Prestidigitation)
+		know_spell(char, Mending)
+		know_spell(char, Prestidigitation)
 		char.features.append(Feature(
 			name="Tinker",
 			description="You can craft tiny clockwork devices with magical effects (e.g., music box, lighter, toy).",
@@ -1179,7 +1144,10 @@ def RockGnomeLineage():
 	return Feature(
 		name="Rock Gnome Lineage",
 		apply=apply,
-		description="You know 【0】Mending and 【0】Prestidigitation. You can create magical clockwork devices. Intelligence is your spellcasting ability. See Spells.",
+		description=(
+			f"You know {spell_mark(Mending)} and {spell_mark(Prestidigitation)}. "
+			"You can create magical clockwork devices. Intelligence is your spellcasting ability. See Spells."
+			),
 		source="Species Lineage"
 	)
 

--- a/AtlasLusoris/Grimoire_of_Features.py
+++ b/AtlasLusoris/Grimoire_of_Features.py
@@ -534,13 +534,30 @@ def BoonTruesight():
 		level=19,
 	)
 
+def owned_feature_names(char):
+	names = set()
+	for feat in getattr(char, "features", []) or []:
+		name = str(getattr(feat, "name", "") or "").strip()
+		if name:
+			names.add(name)
+	for inv in getattr(char, "invocations", []) or []:
+		name = str(getattr(inv, "name", "") or "").strip()
+		if name:
+			names.add(name)
+	return names
+
+
 # ------------- Selector ------------
 def ApplyRandomFeats(char, n=1):
 	print("Random Feat!")
-	available = list(BuildAvailableFeats(char))
-	chosen = random.sample(available, n)
+	owned = owned_feature_names(char)
+	available = [feat for feat in BuildAvailableFeats(char) if feat.name not in owned]
+	if not available:
+		return []
+	chosen = random.sample(available, min(n, len(available)))
 	for feat in chosen:
 		feat(char)   # apply .apply() mutation
+		owned.add(feat.name)
 	return chosen
 
 def BuildAvailableBoon(char):
@@ -629,11 +646,15 @@ def BuildAvailableBoon(char):
 
 def ApplyEpicBoon(char, n=1):
 	print("Epic Boom!")
-	available = list(BuildAvailableBoon(char))
-	chosen = random.sample(available, n)
+	owned = owned_feature_names(char)
+	available = [boon for boon in BuildAvailableBoon(char) if boon.name not in owned]
+	if not available:
+		return []
+	chosen = random.sample(available, min(n, len(available)))
 	for boon in chosen:
 		boon(char)
 		char.features.append(boon)
+		owned.add(boon.name)
 	return chosen
 
 def Fighting_Styles(char=None):
@@ -688,13 +709,10 @@ def add_new_fighting_style(char):
 	description = Fighting_Styles(char)[chosen]
 	if chosen == "Druidic Warrior":
 		from AtlasLusoris.Compass_of_Learned_Spells import (
-			caster_rng, grant_spell, names_line, pick_new, spell_key,
+			catalog_keys, caster_rng, grant_spell, names_line, pick_new,
 			)
 		from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
-		already = set()
-		caster = getattr(char, "spellcaster", None)
-		if caster is not None:
-			already = {spell_key(spell) for spell in getattr(caster, "spells_known", []) or []}
+		already = catalog_keys(getattr(char, "spellcaster", None))
 		picked = pick_new(SPELL_LISTS.get("Druid", {}).get(0, []), 2, caster_rng(char, 0xD11), already)
 		for spell in picked:
 			grant_spell(char, spell)

--- a/AtlasLusoris/Grimoire_of_Features.py
+++ b/AtlasLusoris/Grimoire_of_Features.py
@@ -661,18 +661,10 @@ def Fighting_Styles(char=None):
 		}
 	# Only Rangers get access to Druidic Warrior:
 	if char and "Ranger" in char:
-		from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
-		# pick two distinct druid cantrips:
-		druid_cantrips = SPELL_LISTS["Druid"][0]
-		chosen = random.sample(druid_cantrips, k=2)
-
-		# render them as HTML blocks:
-		cantrip_html = "".join(f"<div class='npc-textbox'>{c}</div>" for c in chosen)
-
 		styles["Druidic Warrior"] = (
 			"You learn two cantrips of your choice from the druid spell list. "
-			"They count as Ranger spells for you, and Wisdom is your spellcasting ability for them."
-			+ cantrip_html
+			"They count as Ranger spells for you, and Wisdom is your spellcasting ability for them. "
+			"See Spells at the end of the sheet."
 			)
 		if char.level >= 18: styles.pop("Blind Fighting", None)
 	return styles
@@ -713,10 +705,25 @@ def add_new_fighting_style(char):
 		print("No new fighting styles to grant!")
 		return None
 	chosen = random.choice(available)
+	description = Fighting_Styles(char)[chosen]
+	if chosen == "Druidic Warrior":
+		from AtlasLusoris.Compass_of_Learned_Spells import (
+			caster_rng, grant_spell, names_line, pick_new, spell_key,
+			)
+		from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
+		already = set()
+		caster = getattr(char, "spellcaster", None)
+		if caster is not None:
+			already = {spell_key(spell) for spell in getattr(caster, "spells_known", []) or []}
+		picked = pick_new(SPELL_LISTS.get("Druid", {}).get(0, []), 2, caster_rng(char, 0xD11), already)
+		for spell in picked:
+			grant_spell(char, spell)
+		if picked:
+			description = description + f" Learned: {names_line(picked)}."
 	feat = Feat(
 		name=chosen,
 		apply=lambda c: None,  # No mutation needed, pure feature
-		description=Fighting_Styles(char)[chosen],
+		description=description,
 		source="Fighting Style"
 	)
 	# Add to features list
@@ -938,25 +945,27 @@ def InvAgonizingBlast():
 
 def InvArmorOfShadows():
 	from AtlasMagia.Lodge_of_Spells import MageArmor
+	from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
 	return Invocation(
 		name="Armor of Shadows",
 		level=2,
-		description= f"""
-			You can cast Mage Armor on yourself at will, without expending a spell slot.
-			<div class="npc-textbox">{MageArmor}</div>
-			""",
+		description=(
+			f"You can cast {spell_mark(MageArmor)} on yourself at will, without expending a spell slot. "
+			"See Spells."
+		),
 		condition=lambda c: "Warlock" in c.char_class,
-		apply=None
+		apply=lambda c: grant_spell(c, MageArmor),
 	)
 
 def InvAscendantStep():
 	from AtlasMagia.Lodge_of_Spells import Levitate
+	from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
 	return Invocation(
 		name="Ascendant Step",
 		level=5,
-		description=f"""You can cast Levitate on yourself at will, no slot. <div class="npc-textbox">{Levitate}</div>""",
+		description=f"You can cast {spell_mark(Levitate)} on yourself at will, no slot. See Spells.",
 		condition=lambda c: getattr(c, "level", 0) >= 5 and "Warlock" in c.char_class,
-		apply=lambda c: None
+		apply=lambda c: grant_spell(c, Levitate),
 	)
 
 def InvDevilsSight():
@@ -976,14 +985,15 @@ def InvDevilsSight():
 
 def InvFiendishVigor():
 	from AtlasMagia.Lodge_of_Spells import FalseLife
+	from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
 	return Invocation(
 		name="Fiendish Vigor",
 		level=2,
-		description= f"""
-			You can cast False Life on yourself at will. Always max HP on False Life.<br> <div class="npc-textbox">{FalseLife}</div>
-			""",
+		description=(
+			f"You can cast {spell_mark(FalseLife)} on yourself at will. Always max HP on False Life. See Spells."
+		),
 		condition=lambda c: getattr(c, "level", 0) >= 2 and "Warlock" in c.char_class,
-		apply=lambda c: None
+		apply=lambda c: grant_spell(c, FalseLife),
 	)
 
 def InvEldritchMind():
@@ -1006,13 +1016,15 @@ def InvPactOfTheBlade():
 	)
 
 def InvPactOfTheChain():
+	from AtlasMagia.Lodge_of_Spells import FindFamiliar
+	from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
 	return Invocation(
 		name="Pact of the Chain",
 		level=2,
-		description="Learn Find Familiar; cast at will; access special forms.",
+		description=f"Learn {spell_mark(FindFamiliar)}; cast at will; access special forms. See Spells.",
 		condition=lambda c: "Warlock" in c.char_class,
 		pact_required="Chain",
-		apply=lambda c: None
+		apply=lambda c: grant_spell(c, FindFamiliar),
 	)
 
 def InvPactOfTheTome():
@@ -1119,6 +1131,8 @@ def GnomishCunning():
 
 def ForestGnomeLineage():
 	def apply(char):
+		from AtlasMagia.Lodge_of_Spells import MinorIllusion, SpeakwithAnimals
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
 		if not hasattr(char, "cantrips"):
 			char.cantrips = []
 		if not hasattr(char, "spells_known"):
@@ -1134,22 +1148,28 @@ def ForestGnomeLineage():
 			"uses_per_day": char.proficiency_bonus,
 			"source": "Species Feature"
 		})
+		grant_spell(char, MinorIllusion)
+		grant_spell(char, SpeakwithAnimals)
 
 	return Feature(
 		name="Forest Gnome Lineage",
 		apply=apply,
-		description="You know the <b>Minor Illusion</b> cantrip. You can cast <b>Speak with Animals</b> a number of times per long rest equal to your proficiency bonus. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
+		description="You know 【0】Minor Illusion. You can cast 【1】Speak with Animals a number of times per long rest equal to your proficiency bonus. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell. See Spells.",
 		source="Species Lineage"
 	)
 
 def RockGnomeLineage():
 	def apply(char):
+		from AtlasMagia.Lodge_of_Spells import Mending, Prestidigitation
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
 		if not hasattr(char, "cantrips"):
 			char.cantrips = []
 		char.cantrips.extend([
 			{"name": "Mending", "casting_stat": "INT", "source": "Species Feature"},
 			{"name": "Prestidigitation", "casting_stat": "INT", "source": "Species Feature"}
 		])
+		grant_spell(char, Mending)
+		grant_spell(char, Prestidigitation)
 		char.features.append(Feature(
 			name="Tinker",
 			description="You can craft tiny clockwork devices with magical effects (e.g., music box, lighter, toy).",
@@ -1159,7 +1179,7 @@ def RockGnomeLineage():
 	return Feature(
 		name="Rock Gnome Lineage",
 		apply=apply,
-		description="You know the *Mending* and *Prestidigitation* cantrips. You can create magical clockwork devices. Intelligence is your spellcasting ability.",
+		description="You know 【0】Mending and 【0】Prestidigitation. You can create magical clockwork devices. Intelligence is your spellcasting ability. See Spells.",
 		source="Species Lineage"
 	)
 
@@ -1293,14 +1313,11 @@ def HealerFeat():
 
 def MagicInitiateCleric():
 	"""
-	Origin feat: Magic Initiate (Cleric):contentReference[oaicite:21]{index=21}.  You learn two Cleric cantrips and one 1st‑level Cleric spell:contentReference[oaicite:22]{index=22}.
+	Origin feat: Magic Initiate (Cleric). Two Cleric cantrips and one 1st-level Cleric spell.
 	"""
-	def apply(char):
-		char.magic_initiate_cleric = True
-
-	return Feat(
+	feat = Feat(
 		name="Magic Initiate (Cleric)",
-		apply=apply,
+		apply=lambda char: None,
 		description=(
 			"You learn two cantrips of your choice from the Cleric spell list. "
 			"Choose one 1st‑level Cleric spell; you can cast it once without a spell slot (recharge on Long Rest). "
@@ -1309,17 +1326,28 @@ def MagicInitiateCleric():
 		source="Background Feat",
 		level=1,
 	)
+	def apply(char):
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, names_line, pick_magic_initiate
+		char.magic_initiate_cleric = True
+		spells = pick_magic_initiate(char, "Cleric")
+		for spell in spells:
+			grant_spell(char, spell)
+		if spells:
+			feat.description = (
+				"You learn two cantrips of your choice from the Cleric spell list "
+				"and one 1st-level Cleric spell, which you can cast once without a slot (Long Rest). "
+				f"Learned: {names_line(spells)}. See Spells."
+			)
+	feat.apply = apply
+	return feat
 
 def MagicInitiateDruid():
 	"""
-	Origin feat: Magic Initiate (Druid):contentReference[oaicite:24]{index=24}.  Similar to the Cleric version but draws spells from the Druid list:contentReference[oaicite:25]{index=25}.
+	Origin feat: Magic Initiate (Druid). Two Druid cantrips and one 1st-level Druid spell.
 	"""
-	def apply(char):
-		char.magic_initiate_druid = True
-
-	return Feat(
+	feat = Feat(
 		name="Magic Initiate (Druid)",
-		apply=apply,
+		apply=lambda char: None,
 		description=(
 			"You learn two cantrips of your choice from the Druid spell list and one 1st‑level Druid spell. "
 			"You can cast the 1st‑level spell once without a spell slot (recharge on Long Rest), and you can replace spells when you level up."
@@ -1327,17 +1355,28 @@ def MagicInitiateDruid():
 		source="Background Feat",
 		level=1,
 	)
+	def apply(char):
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, names_line, pick_magic_initiate
+		char.magic_initiate_druid = True
+		spells = pick_magic_initiate(char, "Druid")
+		for spell in spells:
+			grant_spell(char, spell)
+		if spells:
+			feat.description = (
+				"You learn two Druid cantrips and one 1st-level Druid spell, "
+				"which you can cast once without a slot (Long Rest). "
+				f"Learned: {names_line(spells)}. See Spells."
+			)
+	feat.apply = apply
+	return feat
 
 def MagicInitiateWizard():
 	"""
-	Origin feat: Magic Initiate (Wizard):contentReference[oaicite:27]{index=27}.  Similar to the generic Magic Initiate but pulls from the Wizard list:contentReference[oaicite:28]{index=28}.
+	Origin feat: Magic Initiate (Wizard). Two Wizard cantrips and one 1st-level Wizard spell.
 	"""
-	def apply(char):
-		char.magic_initiate_wizard = True
-
-	return Feat(
+	feat = Feat(
 		name="Magic Initiate (Wizard)",
-		apply=apply,
+		apply=lambda char: None,
 		description=(
 			"You learn two cantrips of your choice from the Wizard spell list and one 1st‑level Wizard spell. "
 			"You can cast the 1st‑level spell once without a spell slot (recharge on Long Rest), and you can replace spells when you level up."
@@ -1345,6 +1384,20 @@ def MagicInitiateWizard():
 		source="Background Feat",
 		level=1,
 	)
+	def apply(char):
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, names_line, pick_magic_initiate
+		char.magic_initiate_wizard = True
+		spells = pick_magic_initiate(char, "Wizard")
+		for spell in spells:
+			grant_spell(char, spell)
+		if spells:
+			feat.description = (
+				"You learn two Wizard cantrips and one 1st-level Wizard spell, "
+				"which you can cast once without a slot (Long Rest). "
+				f"Learned: {names_line(spells)}. See Spells."
+			)
+	feat.apply = apply
+	return feat
 
 def TavernBrawler():
 	"""

--- a/AtlasLusoris/Grimoire_of_Features.py
+++ b/AtlasLusoris/Grimoire_of_Features.py
@@ -1169,6 +1169,107 @@ def RockGnomeLineage():
 		source="Species Lineage"
 	)
 
+
+CHTHONIC_FLAVOR = (
+	"Hades' gates are said to be guarded by grim dogs with several heads, "
+	"strange faceless minotaurs, and foxes with a multitude of tails. "
+	"You find it hard to imagine how you may be related to them."
+	)
+
+FIENDISH_LEGACIES = {
+	"Abyssal": {
+		"resistance": "Poison",
+		"cantrip": "PoisonSpray",
+		"third": "RayofSickness",
+		"fifth": "HoldPerson",
+		},
+	"Chthonic": {
+		"resistance": "Necrotic",
+		"cantrip": "ChillTouch",
+		"third": "FalseLife",
+		"fifth": "RayofEnfeeblement",
+		"flavor": CHTHONIC_FLAVOR,
+		},
+	"Infernal": {
+		"resistance": "Fire",
+		"cantrip": "FireBolt",
+		"third": "HellishRebuke",
+		"fifth": "Darkness",
+		},
+	}
+
+
+def spellcasting_ability_sentence(char):
+	name = ABILITY_NAMES[origin_spell_stat(char)]
+	return f"<b>{name}</b> is your spellcasting ability."
+
+
+def OtherworldlyPresence():
+	from AtlasMagia.Lodge_of_Spells import Thaumaturgy
+	from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+
+	feat = Feature(
+		name="Otherworldly Presence",
+		description=f"You know {spell_mark(Thaumaturgy)}. See Spells.",
+		source="Species Feature",
+		level=1,
+		)
+
+	def apply(char):
+		know_spell(char, Thaumaturgy)
+		feat.description = (
+			f"You know {spell_mark(Thaumaturgy)}. "
+			"It uses the same spellcasting ability as your Fiendish Legacy. See Spells."
+			)
+
+	feat.apply = apply
+	return feat
+
+
+def FiendishLegacy(legacy=None):
+	from AtlasMagia import Lodge_of_Spells as Lodge
+	from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+
+	kind = legacy if legacy in FIENDISH_LEGACIES else random.choice(list(FIENDISH_LEGACIES))
+	spec = FIENDISH_LEGACIES[kind]
+	feat = Feature(
+		name=f"Fiendish Legacy: {kind}",
+		description="",
+		source="Species Feature",
+		level=1,
+		)
+
+	def apply(char):
+		level = int(getattr(char, "level", 1) or 1)
+		cantrip = getattr(Lodge, spec["cantrip"])
+		extra = []
+		if level >= 3:
+			extra.append(getattr(Lodge, spec["third"]))
+		if level >= 5:
+			extra.append(getattr(Lodge, spec["fifth"]))
+		know_spell(char, cantrip)
+		for spell in extra:
+			know_spell(char, spell)
+
+		lines = []
+		flavor = spec.get("flavor")
+		if flavor:
+			lines.append(f"<i>{flavor}</i>")
+		lines.append(f"You have Resistance to {spec['resistance']} damage.")
+		known = [f"You know {spell_mark(cantrip)}."]
+		for spell in extra:
+			known.append(
+				f"You always have {spell_mark(spell)} prepared. "
+				"You can cast it once without a spell slot (Long Rest), "
+				"and you can also spend spell slots to cast it."
+				)
+		known.append(spellcasting_ability_sentence(char))
+		lines.append(" ".join(known) + " See Spells.")
+		feat.description = "<br>".join(lines)
+
+	feat.apply = apply
+	return feat
+
 def Crafter():
 	"""
 	Origin feat: Crafter:contentReference[oaicite:3]{index=3}.  Grants proficiency with three

--- a/AtlasLusoris/Grimoire_of_Spellcasters.py
+++ b/AtlasLusoris/Grimoire_of_Spellcasters.py
@@ -21,6 +21,13 @@ from AtlasLusoris.Compass_of_Learned_Spells import (
 	)
 
 
+from AtlasLusoris.Map_of_Casting_Tables import (
+	LIST_FALLBACK,
+	casting_row,
+	slots_as_map,
+	)
+
+
 SPELL_LISTS = {
 	"test":  {
 			0: [ ],
@@ -449,6 +456,17 @@ SPELL_LISTS = {
 
 
 
+def class_spell_table(name):
+	"""Class list, or a fallback list when this class's table is still empty."""
+	table = SPELL_LISTS.get(name) or {}
+	if any(table.values()):
+		return table
+	fallback = LIST_FALLBACK.get(name)
+	if fallback:
+		return SPELL_LISTS.get(fallback) or {}
+	return table
+
+
 class Spellcaster:
 	def __init__(caster, character, known=None):
 		if known is None:      known = []
@@ -479,7 +497,7 @@ class Spellcaster:
 
 	def available_spells(caster):
 		"""Spells this character can learn, capped by slot level — not character level."""
-		table = SPELL_LISTS.get(caster.list_name(), {}) or SPELL_LISTS.get(caster.character.char_class, {})
+		table = class_spell_table(caster.list_name()) or class_spell_table(caster.character.char_class)
 		max_slot = max_slot_from(caster.spell_slots)
 		unlocked = [lvl for lvl in table if lvl == 0 or lvl <= max_slot]
 		return unique_spells([spell for lvl in unlocked for spell in table[lvl]])
@@ -559,43 +577,19 @@ class Wizard(Spellcaster):
 		return "INT"
 
 	def get_stats(caster, key):
-		table = {
-			1:  {"cantrips": 3, "spells": 4,     "slots": (2,0,0,0,0,0,0,0,0)},
-			2:  {"cantrips": 3, "spells": 5,      "slots": (3,0,0,0,0,0,0,0,0)},
-			3:  {"cantrips": 3, "spells": 6,      "slots": (4,2,0,0,0,0,0,0,0)},
-			4:  {"cantrips": 4, "spells": 7,      "slots": (4,3,0,0,0,0,0,0,0)},
-			5:  {"cantrips": 4, "spells": 9,      "slots": (4,3,2,0,0,0,0,0,0)},
-			6:  {"cantrips": 4, "spells": 10,      "slots": (4,3,3,0,0,0,0,0,0)},
-			7:  {"cantrips": 4, "spells": 11,      "slots": (4,3,3,1,0,0,0,0,0)},
-			8:  {"cantrips": 4, "spells": 12,      "slots": (4,3,3,2,0,0,0,0,0)},
-			9:  {"cantrips": 4, "spells": 14,      "slots": (4,3,3,3,1,0,0,0,0)},
-			10: {"cantrips": 5, "spells": 15,      "slots": (4,3,3,3,2,0,0,0,0)},
-			11: {"cantrips": 5, "spells": 16,      "slots": (4,3,3,3,2,1,0,0,0)},
-			12: {"cantrips": 5, "spells": 16,      "slots": (4,3,3,3,2,1,0,0,0)},
-			13: {"cantrips": 5, "spells": 17,      "slots": (4,3,3,3,2,1,1,0,0)},
-			14: {"cantrips": 5, "spells": 18,      "slots": (4,3,3,3,2,1,1,0,0)},
-			15: {"cantrips": 5, "spells": 19,      "slots": (4,3,3,3,2,1,1,1,0)},
-			16: {"cantrips": 5, "spells": 21,      "slots": (4,3,3,3,2,1,1,1,0)},
-			17: {"cantrips": 5, "spells": 22,      "slots": (4,3,3,3,2,1,1,1,1)},
-			18: {"cantrips": 5, "spells": 23,      "slots": (4,3,3,3,3,1,1,1,1)},
-			19: {"cantrips": 5, "spells": 24,      "slots": (4,3,3,3,3,2,1,1,1)},
-			20: {"cantrips": 5, "spells": 25,      "slots": (4,3,3,3,3,2,2,1,1)},
-			}
-		lvl = caster.level
-		if lvl > 20: lvl = 20
-		value = table.get(lvl, {"cantrips": 0, "spells": 0, "slots": (0,0,0,0)})
+		row = casting_row("Wizard", caster.level)
 		if key == "cantrips":
-			return value["cantrips"]
+			return row.get("cantrips", 0)
 		if key == "spells":
-			return value["spells"]
+			return row.get("prepared", 0)
 		if key == "slots":
-			return {i + 1: val for i, val in enumerate(value["slots"])}
+			return slots_as_map(row.get("slots"))
 
 	def get_spell_slots(caster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		table = SPELL_LISTS.get("Wizard", {})
+		table = class_spell_table("Wizard")
 		cantrips, book = progressive_learn(
 			caster.character,
 			table,
@@ -641,8 +635,7 @@ class Wizard(Spellcaster):
 			<div class="npc-textbox" style="grid-column: span 1;">
 			<h3 style="font-family: 'Iglesia'; font-size:    3.1em; "> Spellbook </h3>
 			When you finish a Long Rest, you may prepare {n} spells from the
-			book — the ones you can speak at any moment. 【prepared】
-			〖written, not prepared〗
+			book — the ones you can speak at any moment.
 			{index}
 			<h2>Arcane Focus</h2>
 			You can use an Arcane Focus as a Spellcasting Focus for your
@@ -673,56 +666,32 @@ class Druid(Spellcaster):
 		return "WIS"
 
 	def get_stats(caster, key):
-		table = {
-			1:  {"cantrips": 2, "spells": 4,	"slots": (2,0,0,0,0,0,0,0,0)},
-			2:  {"cantrips": 2, "spells": 5, 	"slots": (3,0,0,0,0,0,0,0,0)},
-			3:  {"cantrips": 2, "spells": 6,	"slots": (4,2,0,0,0,0,0,0,0)},
-			4:  {"cantrips": 3, "spells": 7, 	"slots": (4,3,0,0,0,0,0,0,0)},
-			5:  {"cantrips": 3, "spells": 9, 	"slots": (4,3,2,0,0,0,0,0,0)},
-			6:  {"cantrips": 3, "spells": 10, 	"slots": (4,3,3,0,0,0,0,0,0)},
-			7:  {"cantrips": 3, "spells": 11, 	"slots": (4,3,3,1,0,0,0,0,0)},
-			8:  {"cantrips": 3, "spells": 12, 	"slots": (4,3,3,2,0,0,0,0,0)},
-			9:  {"cantrips": 3, "spells": 14, 	"slots": (4,3,3,3,1,0,0,0,0)},
-			10: {"cantrips": 4, "spells": 15, 	"slots": (4,3,3,3,2,0,0,0,0)},
-			11: {"cantrips": 4, "spells": 16, 	"slots": (4,3,3,3,2,1,0,0,0)},
-			12: {"cantrips": 4, "spells": 16, 	"slots": (4,3,3,3,2,1,0,0,0)},
-			13: {"cantrips": 4, "spells": 17, 	"slots": (4,3,3,3,2,1,1,0,0)},
-			14: {"cantrips": 4, "spells": 17, 	"slots": (4,3,3,3,2,1,1,0,0)},
-			15: {"cantrips": 4, "spells": 18, 	"slots": (4,3,3,3,2,1,1,1,0)},
-			16: {"cantrips": 4, "spells": 18, 	"slots": (4,3,3,3,2,1,1,1,0)},
-			17: {"cantrips": 4, "spells": 19, 	"slots": (4,3,3,3,2,1,1,1,1)},
-			18: {"cantrips": 4, "spells": 20, 	"slots": (4,3,3,3,3,1,1,1,1)},
-			19: {"cantrips": 4, "spells": 21, 	"slots": (4,3,3,3,3,2,1,1,1)},
-			20: {"cantrips": 4, "spells": 22, 	"slots": (4,3,3,3,3,2,2,1,1)},
-			}
-		lvl = caster.level
-		if lvl > 20: lvl = 20
-		value = table.get(lvl, {"cantrips": 0, "spells": 0, "slots": (0,0,0,0)})
+		row = casting_row("Druid", caster.level)
 		if key == "cantrips":
-			result = value["cantrips"]
+			result = row.get("cantrips", 0)
 			if getattr(caster.character, "Primal_Order", None) == "Magician":
 				result += 1
 			return result
 		if key == "spells":
-			return value["spells"]
+			return row.get("prepared", 0)
 		if key == "slots":
-			return {i + 1: val for i, val in enumerate(value["slots"])}
+			return slots_as_map(row.get("slots"))
 
 	def get_spell_slots(caster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		table = SPELL_LISTS.get("Druid", {})
+		table = class_spell_table("Druid")
 		cantrips, book = progressive_learn(
 			caster.character,
 			table,
 			caster.level,
 			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
-			known_at=lambda lvl: 2 * lvl + 4,
+			known_at=lambda lvl: stats_at_level(caster, lvl, "spells"),
 			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
 			salt=CLASS_SALT["Druid"],
 			)
-		finish_learning(caster, cantrips, book, prepared_count=caster.get_stats("spells"))
+		finish_learning(caster, cantrips, book)
 
 	def modifier(caster):
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
@@ -775,51 +744,21 @@ class Ranger(Spellcaster):
 		wis_mod = self.modifier()
 		return max(1, (self.level // 2) + wis_mod)
 
-	# map the slot tuple for this level into {level: slots}
-	def get_spell_slots(self):
-		row = Ranger.HALF_CASTER_SLOTS[self.level]
-		return {i + 1: n for i, n in enumerate(row) if n}
-
-	# same helper used by base class
 	def modifier(self) -> int:
 		return (getattr(self.character.AS, self.get_casting_stat()) - 10) // 2
 
 	def get_stats(caster, key):
-		"""Spellcasting stats: spell slots and number of prepared spells."""
-		table = {
-			1:  {"prepared": 2,  "slots": (2,0,0,0,0)},
-			2:  {"prepared": 3,  "slots": (2,0,0,0,0)},
-			3:  {"prepared": 4,  "slots": (3,0,0,0,0)},
-			4:  {"prepared": 5,  "slots": (3,0,0,0,0)},
-			5:  {"prepared": 6,  "slots": (4,2,0,0,0)},
-			6:  {"prepared": 6,  "slots": (4,2,0,0,0)},
-			7:  {"prepared": 7,  "slots": (4,3,0,0,0)},
-			8:  {"prepared": 7,  "slots": (4,3,0,0,0)},
-			9:  {"prepared": 9,  "slots": (4,3,2,0,0)},
-			10: {"prepared": 9,  "slots": (4,3,2,0,0)},
-			11: {"prepared": 10, "slots": (4,3,3,0,0)},
-			12: {"prepared": 10, "slots": (4,3,3,0,0)},
-			13: {"prepared": 11, "slots": (4,3,3,1,0)},
-			14: {"prepared": 11, "slots": (4,3,3,1,0)},
-			15: {"prepared": 12, "slots": (4,3,3,2,0)},
-			16: {"prepared": 12, "slots": (4,3,3,2,0)},
-			17: {"prepared": 14, "slots": (4,3,3,3,1)},
-			18: {"prepared": 14, "slots": (4,3,3,3,1)},
-			19: {"prepared": 15, "slots": (4,3,3,3,2)},
-			20: {"prepared": 15, "slots": (4,3,3,3,2)},
-		}
-		lvl = min(caster.level, 20)
-		entry = table.get(lvl, {"prepared": 0, "slots": (0,0,0,0,0)})
+		row = casting_row("Ranger", caster.level)
 		if key == "prepared":
-			return entry["prepared"]
+			return row.get("prepared", 0)
 		if key == "slots":
-			return {i + 1: val for i, val in enumerate(entry["slots"])}
+			return slots_as_map(row.get("slots"))
 
 	def get_spell_slots(caster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		table = SPELL_LISTS.get("Ranger", {})
+		table = class_spell_table("Ranger")
 		cantrips, known = progressive_learn(
 			caster.character,
 			table,
@@ -867,38 +806,64 @@ class Ranger(Spellcaster):
 class Sorcerer(Spellcaster):
 	def __init__(caster, character):
 		super().__init__(character)
-		caster.metamagic_points = caster.level  # Basic rule, extend as needed
+		lvl = getattr(character, "level", 1)
+		caster.metamagic_points = 0 if lvl < 2 else lvl
 
 	def get_casting_stat(caster):
 		return "CHA"
 
+	def get_stats(caster, key):
+		row = casting_row("Sorcerer", caster.level)
+		if key == "cantrips":
+			return row.get("cantrips", 0)
+		if key in ("spells", "prepared"):
+			return row.get("prepared", 0)
+		if key == "slots":
+			return slots_as_map(row.get("slots"))
+
 	def get_spell_slots(caster):
-		slots_table = {
-			1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2},
-			4: {1: 4, 2: 3}, # Extend as needed
-		}
-		return slots_table.get(caster.level, {})
+		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		table = SPELL_LISTS.get("Sorcerer", {})
-		slots_by_level = {
-			1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3},
-			}
+		table = class_spell_table("Sorcerer")
 		cantrips, known = progressive_learn(
 			caster.character,
 			table,
 			caster.level,
-			cantrips_at=lambda lvl: 4 if lvl < 4 else 5 if lvl < 10 else 6,
-			known_at=lambda lvl: max(0, lvl + 1),
-			slots_at=lambda lvl: slots_by_level.get(min(lvl, 4), {1: 2}),
+			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
+			known_at=lambda lvl: stats_at_level(caster, lvl, "spells"),
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
 			salt=CLASS_SALT["Sorcerer"],
 			)
 		finish_learning(caster, cantrips, known)
 
 	def html_rules(caster):
-		base = super().html_rules()
-		points = getattr(caster, "metamagic_points", caster.level)
-		return base + f"<div class='npc-textbox'><p><strong>Metamagic Points:</strong> {points}</p></div>"
+		n = caster.get_stats("prepared")
+		index = html_spell_index(caster)
+		slots_html = caster.html_slots()
+		points = getattr(caster, "metamagic_points", 0)
+		points_line = ""
+		if points:
+			points_line = f"<p><strong>Sorcery Points:</strong> {points}</p>"
+		return f"""
+			<div class="npc-textbox" style="grid-column: span 3;">
+				<h1 style="font-family: 'Iglesia'; font-size: 3.1em;">Sorcerer Spellcasting</h1>
+				<p>You prepare {n} Sorcerer spells. Charisma is your spellcasting ability.</p>
+				{points_line}
+				</div>
+			<div class="npc-textbox">
+				<h2>Spell Slots:</h2>
+				{slots_html}
+				<p>You regain all expended slots when you finish a Long Rest.</p>
+				</div>
+			<div class="npc-textbox">
+				<b>Spell Save DC:</b> {caster.spell_save_dc()}<br>
+				<b>Spell Attack Bonus:</b> +{caster.spell_attack_bonus()}
+				</div>
+			<div class="npc-textbox">
+				{index}
+				</div>
+			"""
 
 	def __str__(caster):
 		return caster.html_rules()
@@ -1237,30 +1202,6 @@ class ArcaneTrickster(Spellcaster):
 		return trickster.html_rules()
 
 
-# Warlock spellcasting progression for 2024 PHB
-WARLOCK_SPELLCASTING_TABLE = {
-		1:  {"cantrips": 2, "prepared": 3,  "slots": (1,),   "slot_level": 1},
-		2:  {"cantrips": 2, "prepared": 3,  "slots": (2,),   "slot_level": 1},
-		3:  {"cantrips": 2, "prepared": 4,  "slots": (2,),   "slot_level": 2},
-		4:  {"cantrips": 3, "prepared": 5,  "slots": (2,),   "slot_level": 2},
-		5:  {"cantrips": 3, "prepared": 6,  "slots": (2,),   "slot_level": 3},
-		6:  {"cantrips": 3, "prepared": 7,  "slots": (2,),   "slot_level": 3},
-		7:  {"cantrips": 3, "prepared": 8,  "slots": (2,),   "slot_level": 4},
-		8:  {"cantrips": 3, "prepared": 9,  "slots": (2,),   "slot_level": 4},
-		9:  {"cantrips": 3, "prepared": 10, "slots": (2,),   "slot_level": 5},
-		10: {"cantrips": 4, "prepared": 10, "slots": (2,),   "slot_level": 5},
-		11: {"cantrips": 4, "prepared": 11, "slots": (3,),   "slot_level": 5},
-		12: {"cantrips": 4, "prepared": 11, "slots": (3,),   "slot_level": 5},
-		13: {"cantrips": 4, "prepared": 12, "slots": (3,),   "slot_level": 5},
-		14: {"cantrips": 4, "prepared": 12, "slots": (3,),   "slot_level": 5},
-		15: {"cantrips": 4, "prepared": 13, "slots": (3,),   "slot_level": 5},
-		16: {"cantrips": 4, "prepared": 13, "slots": (3,),   "slot_level": 5},
-		17: {"cantrips": 4, "prepared": 14, "slots": (4,),   "slot_level": 5},
-		18: {"cantrips": 4, "prepared": 14, "slots": (4,),   "slot_level": 5},
-		19: {"cantrips": 4, "prepared": 15, "slots": (4,),   "slot_level": 5},
-		20: {"cantrips": 4, "prepared": 15, "slots": (4,),   "slot_level": 5},
-		}
-
 def genie_kind(character):
 	kind = getattr(character, "genie_kind", None)
 	if kind:
@@ -1356,24 +1297,22 @@ class Warlock(Spellcaster):
 		return "CHA"
 
 	def get_stats(caster, key):
-		lvl = min(caster.level, 20)
-		value = WARLOCK_SPELLCASTING_TABLE.get(lvl, WARLOCK_SPELLCASTING_TABLE[20])
+		row = casting_row("Warlock", caster.level)
 		if key == "cantrips":
-			return value["cantrips"]
+			return row.get("cantrips", 0)
 		if key == "prepared":
-			return value["prepared"]
+			return row.get("prepared", 0)
 		if key == "slots":
-			# Unlike wizards, Warlocks only ever have one slot level at a time
-			return {value["slot_level"]: value["slots"][0]}
+			return {row["slot_level"]: row["slots"]}
 		if key == "slot_level":
-			return value["slot_level"]
+			return row["slot_level"]
 
 	def get_spell_slots(caster):
 		return caster.get_stats("slots")
 
 	def available_spells(caster):
 		"""Returns all spells this character can *prepare* at their current level."""
-		table = SPELL_LISTS.get(caster.character.char_class, {})
+		table = class_spell_table(caster.character.char_class)
 		max_slot = caster.get_stats("slot_level")
 		# Only show spells up to max_slot (warlock can never prepare 6+)
 		unlocked = [lvl for lvl in table if lvl <= max_slot]
@@ -1381,7 +1320,7 @@ class Warlock(Spellcaster):
 		return spells
 
 	def prepare_spells(caster):
-		table = SPELL_LISTS.get("Warlock", {})
+		table = class_spell_table("Warlock")
 		cantrips, known = progressive_learn(
 			caster.character,
 			table,

--- a/AtlasLusoris/Grimoire_of_Spellcasters.py
+++ b/AtlasLusoris/Grimoire_of_Spellcasters.py
@@ -2,6 +2,23 @@
 
 import random
 from AtlasMagia.Lodge_of_Spells import *
+from AtlasLusoris.Compass_of_Learned_Spells import (
+	CLASS_SALT,
+	catalog_spells,
+	caster_rng,
+	finish_learning,
+	grant_spell,
+	html_spell_catalog,
+	html_spell_index,
+	max_slot_from,
+	pick_new,
+	progressive_learn,
+	spell_key,
+	spell_level,
+	spell_mark,
+	stats_at_level,
+	unique_spells,
+	)
 
 
 SPELL_LISTS = {
@@ -438,6 +455,10 @@ class Spellcaster:
 		caster.character     = character
 		caster.level         = character.level
 		caster.casting_stat = caster.get_casting_stat()
+		caster.granted_spells = []
+		caster.always_prepared = set()
+		caster.prepared_spells = []
+		caster.catalog_known = True
 		caster.spell_slots     =  caster.get_spell_slots()
 		caster.spells_available = caster.available_spells()
 		caster.spells_known = known
@@ -450,13 +471,18 @@ class Spellcaster:
 		slots_table = {}
 		return slots_table
 
+	def list_name(caster):
+		subclass = getattr(caster.character, "subclass", None)
+		if subclass in SPELL_LISTS:
+			return subclass
+		return getattr(caster, "class_name", None) or caster.character.char_class
+
 	def available_spells(caster):
-		"""Return all spells this character can *learn* at their current level."""
-		table = SPELL_LISTS.get(caster.character.char_class, {})
-		# Collapse all spell levels the character has unlocked
-		unlocked = [lvl for lvl in table if lvl <= caster.level]
-		spells = [s for lvl in unlocked for s in table[lvl]]
-		return spells
+		"""Spells this character can learn, capped by slot level — not character level."""
+		table = SPELL_LISTS.get(caster.list_name(), {}) or SPELL_LISTS.get(caster.character.char_class, {})
+		max_slot = max_slot_from(caster.spell_slots)
+		unlocked = [lvl for lvl in table if lvl == 0 or lvl <= max_slot]
+		return unique_spells([spell for lvl in unlocked for spell in table[lvl]])
 
 	def prepare_spells(caster):
 		pass
@@ -472,28 +498,46 @@ class Spellcaster:
 		stat_mod = caster.modifier()
 		return prof + stat_mod
 
-	def __str__(caster):
-		spells_names = "".join(f"<li>〖{spell.level}〗{spell.name}</li>" for spell in caster.spells_known)
-		slots_html = ", ".join(f"Level {lvl}: {num}" for lvl, num in caster.spell_slots.items())
-		spells_html = "".join(f"""<div class="npc-textbox">{spell}</div>""" for spell in caster.spells_known)
+	def modifier(caster):
+		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
+	def html_slots(caster):
+		slots = caster.spell_slots or {}
+		return "<br>".join(
+			f"<b>Level {lvl}</b>: <i>{num}</i>"
+			for lvl, num in slots.items()
+			if num
+			)
+
+	def html_rules(caster):
+		index = html_spell_index(caster)
+		slots_html = caster.html_slots()
 		return f"""
-			<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">{caster.character.char_class} Spellcasting</h1>
-			<p><b>Spell Slots:</b> {slots_html}</p>
-			<ul style="list-style-type: '🪄'; text-align: left; font-family: 'Iglesia'">{spells_names}</ul>
-			</div>
-			<div class="npc-textbox" style="margin-bottom: 1em;">
+			<div class="npc-textbox" style="grid-column: span 3;">
+				<h1 style="font-family: 'Iglesia'; font-size: 3.1em;">{caster.character.char_class} Spellcasting</h1>
+				</div>
+			<div class="npc-textbox">
+				<h2>Spell Slots:</h2>
+				{slots_html}
+				<p>You regain all expended slots when you finish a Long Rest.</p>
+				</div>
+			<div class="npc-textbox">
 				<b>Spell Save DC:</b> {caster.spell_save_dc()}<br>
 				<b>Spell Attack Bonus:</b> +{caster.spell_attack_bonus()}
 				</div>
-			{spells_html}
-		"""
+			<div class="npc-textbox">
+				{index}
+				</div>
+			"""
+
+	def html_catalog(caster):
+		return html_spell_catalog(caster)
+
+	def __str__(caster):
+		return caster.html_rules()
 
 	def html(caster):
-		if not caster.spells_known:
-			return "<i>No spells known</i>"
-		list_items = "".join(f"<li>{s.name}</li>" for s in caster.spells_known)
-		return f"""<div class="npc-textbox"><b>Spellcasting</b><ul>{list_items}</ul></div>"""
+		return caster.html_rules()
 
 class Wizard(Spellcaster):
 	def __init__(caster, character, known=None):
@@ -501,6 +545,10 @@ class Wizard(Spellcaster):
 		caster.class_name     = "Wizard"
 		caster.character     = character
 		caster.level         = character.level
+		caster.granted_spells = []
+		caster.always_prepared = set()
+		caster.prepared_spells = []
+		caster.catalog_known = True
 		caster.spell_slots     =  caster.get_spell_slots()
 		caster.spells_available = caster.available_spells()
 		caster.spells_known = known
@@ -547,51 +595,28 @@ class Wizard(Spellcaster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		num_spells = caster.level*2 + 4
-		available = caster.available_spells()
-		caster.spells_known = random.sample(available, min(len(available), num_spells))
+		table = SPELL_LISTS.get("Wizard", {})
+		cantrips, book = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
+			known_at=lambda lvl: 2 * lvl + 4,
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
+			salt=CLASS_SALT["Wizard"],
+			)
+		finish_learning(caster, cantrips, book, prepared_count=caster.get_stats("spells"))
 
 	def modifier(caster):
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
 	def html(caster):
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
+	def html_rules(caster):
 		n = caster.get_stats("spells")
-		def spell_level(spell):
-			try:
-				return int(spell.level)
-			except (TypeError, ValueError):
-				return 0
-		cantrips = [s for s in caster.spells_known if spell_level(s) == 0]
-		other_spells = [s for s in caster.spells_known if spell_level(s) > 0]
-
-		random.shuffle(other_spells)
-		prepared = other_spells[:n]
-		unprepared = other_spells[n:]
-		all_spells = sorted(prepared + unprepared, key=lambda s: (spell_level(s), s.name))
-		spells = ""
-		for spell in cantrips:
-			spells += f"<li>【{spell.level}】{spell.name}</li>"
-		for spell in all_spells:
-			if spell in prepared or spell_level(spell)==0:
-				spells += f"<li>【{spell.level}】{spell.name}</li>"
-			else:
-				spells += f"<li>〖{spell.level}〗{spell.name}</li>"
-		slots_html = "<br>".join(
-			f"<b>Level {lvl}</b>: <i>{num}</i>"
-			for lvl, num in caster.spell_slots.items()
-			if num  # This skips levels with 0 slots
-			)
-		spells_html = "".join(
-			f"""<div class="npc-textbox">{spell}</div>"""
-			for spell in cantrips
-			)
-		spells_html += "".join(
-			f"""<div class="npc-textbox">{spell}</div>"""
-			for spell in all_spells
-			)
+		index = html_spell_index(caster)
+		slots_html = caster.html_slots()
 		return f"""
 			<div class="npc-textbox" style="grid-column: span 3;">
 				<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">
@@ -619,15 +644,16 @@ class Wizard(Spellcaster):
 			When you finish a Long Rest, you may prepare {n} names from the
 			book — the ones you can speak at any moment. 【prepared】
 			〖written, not prepared〗
-			<ul style="list-style-type: '🪄'; text-align: left; font-family: 'Iglesia' ">
-				{spells}</ul>
+			{index}
 			<h2>Arcane Focus</h2>
 			You can use an Arcane Focus (wand, scepter, orb, staff) as a
 			Spellcasting Focus for your Wizard spells — a tool for aiming
 			a name without shouting it into bare air.
 			</div>
-			{spells_html}
 			"""
+
+	def __str__(caster):
+		return caster.html_rules()
 
 class Druid(Spellcaster):
 	def __init__(caster, character, known=None):
@@ -635,6 +661,10 @@ class Druid(Spellcaster):
 		caster.class_name     = "Druid"
 		caster.character     = character
 		caster.level         = character.level
+		caster.granted_spells = []
+		caster.always_prepared = set()
+		caster.prepared_spells = []
+		caster.catalog_known = True
 		caster.spell_slots     =  caster.get_spell_slots()
 		caster.spells_available = caster.available_spells()
 		caster.spells_known = known
@@ -672,7 +702,7 @@ class Druid(Spellcaster):
 		value = table.get(lvl, {"cantrips": 0, "spells": 0, "slots": (0,0,0,0)})
 		if key == "cantrips":
 			result = value["cantrips"]
-			if character.Primal_Order and character.Primal_Order == "Magician":
+			if getattr(caster.character, "Primal_Order", None) == "Magician":
 				result += 1
 			return result
 		if key == "spells":
@@ -684,46 +714,28 @@ class Druid(Spellcaster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		num_spells = caster.level*2 + 4
-		available = caster.available_spells()
-		caster.spells_known = random.sample(available, min(len(available), num_spells))
+		table = SPELL_LISTS.get("Druid", {})
+		cantrips, book = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
+			known_at=lambda lvl: 2 * lvl + 4,
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
+			salt=CLASS_SALT["Druid"],
+			)
+		finish_learning(caster, cantrips, book, prepared_count=caster.get_stats("spells"))
 
 	def modifier(caster):
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
 	def html(caster):
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
+	def html_rules(caster):
 		n = caster.get_stats("spells")
-		cantrips = [s for s in caster.spells_known if s.level == 0]
-		other_spells = [s for s in caster.spells_known if s.level > 0]
-
-		random.shuffle(other_spells)
-		prepared = other_spells[:n]
-		unprepared = other_spells[n:]
-		all_spells = sorted(prepared + unprepared, key=lambda s: (s.level, s.name))
-		spells = ""
-		for spell in cantrips:
-			spells += f"<li>【{spell.level}】{spell.name}</li>"
-		for spell in all_spells:
-			if spell in prepared or spell.level==0:
-				spells += f"<li>【{spell.level}】{spell.name}</li>"
-			else:
-				spells += f"<li>〖{spell.level}〗{spell.name}</li>"
-		slots_html = "<br>".join(
-			f"<b>Level {lvl}</b>: <i>{num}</i>"
-			for lvl, num in caster.spell_slots.items()
-			if num  # This skips levels with 0 slots
-			)
-		spells_html = "".join(
-			f"""<div class="npc-textbox">{spell}</div>"""
-			for spell in cantrips
-			)
-		spells_html += "".join(
-			f"""<div class="npc-textbox">{spell}</div>"""
-			for spell in all_spells
-			)
+		index = html_spell_index(caster)
+		slots_html = caster.html_slots()
 		return f"""
 			<div class="npc-textbox" style="grid-column: span 3;">
 				<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">
@@ -745,13 +757,14 @@ class Druid(Spellcaster):
 			<div class="npc-textbox" style="grid-column: span 1;">
 			<h3 style="font-family: 'Iglesia'; font-size:    3.1em; "> SpellBook </h3>
 			You may prepare {n} spells whenever you finish a Long Rest, that you can use at any moment, from your book of spells:
-			<ul style="list-style-type: '🪄'; text-align: left; font-family: 'Iglesia' ">
-				{spells}</ul>
+			{index}
 			<h2>Arcane Focus</h2>
 			You can use an Arcane Focus (such as a wand or scepter),  as a Spellcasting Focus for your Druid spells.
 			</div>
-			{spells_html}
 			"""
+
+	def __str__(caster):
+		return caster.html_rules()
 
 class Ranger(Spellcaster):
 	def __init__(self, character, known: list[Spell] | None = None):
@@ -808,34 +821,28 @@ class Ranger(Spellcaster):
 		return caster.get_stats("slots")
 
 	def prepare_spells(caster):
-		n = caster.get_stats("prepared")
-		available = [s for s in caster.available_spells() if s.level > 0]
-		random.shuffle(available)
-		caster.spells_known = available[:n]
+		table = SPELL_LISTS.get("Ranger", {})
+		cantrips, known = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: 0,
+			known_at=lambda lvl: stats_at_level(caster, lvl, "prepared"),
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
+			salt=CLASS_SALT["Ranger"],
+			)
+		finish_learning(caster, cantrips, known)
 
 	def modifier(caster):
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
 	def html(caster):
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
+	def html_rules(caster):
 		n = caster.get_stats("prepared")
-
-		prepared = caster.spells_known[:n]
-		unprepared = caster.spells_known[n:]
-		all_spells = sorted(prepared + unprepared, key=lambda s: (s.level, s.name))
-		spells = "".join(
-			f"<li>【{s.level}】{s.name}</li>" if s in prepared else f"<li>〖{s.level}〗{s.name}</li>"
-			for s in all_spells
-		)
-		slots_html = "<br>".join(
-			f"<b>Level {lvl}</b>: <i>{num}</i>"
-			for lvl, num in caster.spell_slots.items()
-			if num
-		)
-		spells_descriptions = "".join(f'<div class="npc-textbox">{spell}</div>' for spell in all_spells)
-
+		index = html_spell_index(caster, bullet="🍀")
+		slots_html = caster.html_slots()
 		return f"""
 		<div class="npc-textbox" style="grid-column: span 3;">
 			<h1 style="font-family: 'Iglesia'; font-size: 3.1em;">Ranger Spellcasting</h1>
@@ -852,12 +859,12 @@ class Ranger(Spellcaster):
 		</div>
 		<div class="npc-textbox" style="grid-column: span 1;">
 			<h3 style="font-family: 'Iglesia'; font-size: 3.1em;">Spell List</h3>
-			<ul style="list-style-type: '🍀'; font-family: 'Iglesia'; text-align: left;">
-				{spells}
-			</ul>
+			{index}
 		</div>
-		{spells_descriptions}
 		"""
+
+	def __str__(caster):
+		return caster.html_rules()
 
 class Sorcerer(Spellcaster):
 	def __init__(caster, character):
@@ -875,13 +882,28 @@ class Sorcerer(Spellcaster):
 		return slots_table.get(caster.level, {})
 
 	def prepare_spells(caster):
-		num_spells = caster.level + 1
-		available = caster.available_spells()
-		caster.spells_known = random.sample(available, min(len(available), num_spells))
+		table = SPELL_LISTS.get("Sorcerer", {})
+		slots_by_level = {
+			1: {1: 2}, 2: {1: 3}, 3: {1: 4, 2: 2}, 4: {1: 4, 2: 3},
+			}
+		cantrips, known = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: 4 if lvl < 4 else 5 if lvl < 10 else 6,
+			known_at=lambda lvl: max(0, lvl + 1),
+			slots_at=lambda lvl: slots_by_level.get(min(lvl, 4), {1: 2}),
+			salt=CLASS_SALT["Sorcerer"],
+			)
+		finish_learning(caster, cantrips, known)
+
+	def html_rules(caster):
+		base = super().html_rules()
+		points = getattr(caster, "metamagic_points", caster.level)
+		return base + f"<div class='npc-textbox'><p><strong>Metamagic Points:</strong> {points}</p></div>"
 
 	def __str__(caster):
-		base_str = super().__str__()
-		return base_str + f"<p><strong>Metamagic Points:</strong> {caster.metamagic_points}</p>"
+		return caster.html_rules()
 
 
 MONK_TECHNIQUE_LEVELS = [
@@ -898,6 +920,11 @@ class Monk(Spellcaster):
 		caster.level = character.Level
 		caster.casting_stat = caster.get_casting_stat()
 		caster.focus_points = caster.get_focus_points()
+		caster.granted_spells = []
+		caster.always_prepared = set()
+		caster.prepared_spells = []
+		caster.catalog_known = False
+		caster.spell_slots = {}
 
 	def get_casting_stat(caster):
 		return "WIS"
@@ -928,9 +955,9 @@ class Monk(Spellcaster):
 		return (getattr(self.character.AS, "WIS", 10) - 10) // 2
 
 	def html(caster):
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
+	def html_rules(caster):
 		features = caster.spells_known
 		symb = random.choice(["☯","☯︎","࿊","࿋","࿌","࿅", "☮",
 			"☥", "☣", "𓂀", "𖥂", "𖨢", "⧊", "⧋","⚳", "⚴", "⚸",
@@ -990,6 +1017,10 @@ class Monk(Spellcaster):
 
 		"""
 
+	def __str__(caster):
+		return caster.html_rules()
+
+
 def get_monk_focus_features(level, subclass=None):
 	features = []
 	for lvl, feats in MONK_TECHNIQUE_LEVELS:
@@ -1040,56 +1071,45 @@ class EldritchKnight(Spellcaster):
 		return caster.get_stats("slots")
 
 	def available_spells(caster):
-		"""Return all spells this character can *learn* at their current level."""
+		"""Spells this Eldritch Knight can learn, capped by slot level."""
 		table = (SPELL_LISTS.get(caster.character.subclass)
+				or SPELL_LISTS.get("Eldritch Knight")
 				or SPELL_LISTS.get("Wizard", {}))
-		# Collapse all spell levels the character has unlocked
-		unlocked = [lvl for lvl in table if lvl <= caster.level]
-		spells = [s for lvl in unlocked for s in table[lvl]]
-		for lvl in unlocked:
-			spells.extend(table[lvl])
-		return spells
+		max_slot = max_slot_from(caster.spell_slots)
+		unlocked = [lvl for lvl in table if lvl == 0 or lvl <= max_slot]
+		return unique_spells([spell for lvl in unlocked for spell in table[lvl]])
 
 	def prepare_spells(caster):
-		cantrip_pool = [s for s in caster.spells_available if int(s.level) == 0]
-		leveled_pool = [s for s in caster.spells_available if int(s.level) > 0]
-
-		caster.spells_known = random.sample(cantrip_pool, min(len(cantrip_pool), caster.get_stats("cantrips")))
-
-		slots = caster.get_stats("slots")
-		weights = {lvl: slots.get(lvl, 0) for lvl in range(1, 10)}
-		leveled_pool = list({s.name: s for s in leveled_pool}.values())
-		leveled_weighted = [(s, weights.get(int(s.level), 0)) for s in leveled_pool if weights.get(int(s.level), 0) > 0]
-
-		spells, spell_weights = zip(*leveled_weighted) if leveled_weighted else ([], [])
-
-		chosen = random.choices(spells, weights=spell_weights, k=min(len(spells), caster.get_stats("spells")))
-		unique_chosen = []
-		seen = set()
-		for s in chosen:
-			if s.name not in seen:
-				unique_chosen.append(s)
-				seen.add(s.name)
-		caster.spells_known += unique_chosen[:caster.get_stats("spells")]
+		table = (SPELL_LISTS.get(caster.character.subclass)
+				or SPELL_LISTS.get("Eldritch Knight")
+				or SPELL_LISTS.get("Wizard", {}))
+		cantrips, known = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
+			known_at=lambda lvl: stats_at_level(caster, lvl, "spells"),
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
+			salt=CLASS_SALT["Eldritch Knight"],
+			)
+		finish_learning(caster, cantrips, known)
 
 
 	def modifier(caster):
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
 	def html(caster):
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
-		ordered_spells = sorted(caster.spells_known, key=lambda s: int(s.level))
-		spells_names = "".join(f"<li>〖{spell.level}〗{spell.name}</li>" for spell in ordered_spells)
-		spells_html = "".join(f"""<div class="npc-textbox">{spell}</div>""" for spell in ordered_spells)
-		slots_html = "<br>".join(f"<b>Level {lvl}</b>: <i>{num}</i> " for lvl, num in caster.spell_slots.items())
+	def html_rules(caster):
+		index = html_spell_index(caster, bullet="♟️")
+		slots_html = caster.html_slots()
 		return f"""
 			<div class="npc-textbox" style="grid-column: span 1;">
 			<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">{caster.character.subclass} Spellcasting</h1>
 			<p> Eldritch Knights combine the martial mastery common to all Fighters with a careful study of magic. Their spells both complement and extend their combat skills.<br> You have learned to cast spells. </p>
 			<h2>Spell Slots:</h2> {slots_html} <br>  You regain all expended slots when you finish a Long Rest.</p>
-			<ul style="list-style-type: '♟️'; text-align: left; font-family: 'Iglesia' ">{spells_names}</ul>
+			{index}
 			<h2>Arcane Focus</h2>
 			You can use an Arcane Focus (such as a wand or scepter),  as a Spellcasting Focus for your Wizard spells.
 			</div>
@@ -1097,8 +1117,10 @@ class EldritchKnight(Spellcaster):
 				<b>Spell Save DC:</b> {caster.spell_save_dc()}<br>
 				<b>Spell Attack Bonus:</b> +{caster.spell_attack_bonus()}
 				</div>
-			{spells_html}
 			"""
+
+	def __str__(caster):
+		return caster.html_rules()
 
 class ArcaneTrickster(Spellcaster):
 	"""
@@ -1147,65 +1169,40 @@ class ArcaneTrickster(Spellcaster):
 		return trickster.get_stats("slots")
 
 	def available_spells(trickster):
-		"""Return all spells this Arcane Trickster can learn/cast at their current level."""
-		# Prefer the tailored Arcane Trickster list
+		"""Spells this Arcane Trickster can learn, capped by slot level."""
 		source = (
 			SPELL_LISTS.get("Arcane Trickster")
-			or
-			SPELL_LISTS.get("Wizard")
+			or SPELL_LISTS.get("Wizard")
+			or {}
 			)
-		if not source:
-			return []
-		# Unlock spells up to allowed level
-		lvl = getattr(trickster.character, "level", getattr(trickster.character, "Level", 1))
-		# Find max spell slot level available
-		max_slot = max(i+1 for i, n in enumerate(trickster.get_stats("slots").values()) if n > 0)
-		unlocked_levels = [k for k in source if k <= max_slot]
-		# Collate spells
-		spells = [spell for lvl in unlocked_levels for spell in source[lvl]]
-		return spells
+		max_slot = max_slot_from(trickster.get_stats("slots"))
+		unlocked = [key for key in source if key == 0 or key <= max_slot]
+		return unique_spells([spell for lvl in unlocked for spell in source[lvl]])
 
 	def prepare_spells(trickster):
 		"""
 		Select cantrips and prepared spells for Arcane Trickster.
 		Mage Hand is always known and cannot be replaced.
 		"""
-		# Cantrips - always include Mage Hand if present
-		available_cantrips = [s for s in trickster.spells_available if int(s.level) == 0]
-		mage_hand = next((c for c in available_cantrips if c.name == "Mage Hand"), None)
-		other_cantrips = [c for c in available_cantrips if c.name != "Mage Hand"]
-
-		n_cantrips = trickster.get_stats("cantrips")
-		trickster.spells_known = [mage_hand] if mage_hand else []
-		needed = n_cantrips - len(trickster.spells_known)
-
-		if needed > 0:
-			suggested = [MindSliver, MinorIllusion]
-			chosen = []
-			for rec in suggested:
-				found = next((c for c in other_cantrips if c.name == rec), None)
-				if found and found not in chosen:
-					chosen.append(found)
-			remaining = [c for c in other_cantrips if c not in chosen]
-			random.shuffle(remaining)
-			chosen += remaining
-			trickster.spells_known += chosen[:needed]
-		# Now select leveled spells (prepared)
-		n_prepared = trickster.get_stats("prepared")
-		leveled_pool = [s for s in trickster.spells_available if int(s.level) > 0]
-
-		# Optionally: Recommended spells for level 3
-		recommended = ["Charm Person", "Disguise Self", "Fog Cloud"]
-		chosen_prepared = []
-		for rec in recommended:
-			found = next((s for s in leveled_pool if s.name == rec), None)
-			if found and found not in chosen_prepared:
-				chosen_prepared.append(found)
-		# Fill remaining randomly
-		remaining = [s for s in leveled_pool if s not in chosen_prepared]
-		random.shuffle(remaining)
-		chosen_prepared += remaining[:max(0, n_prepared - len(chosen_prepared))]
-		trickster.spells_known += chosen_prepared[:n_prepared]
+		source = (
+			SPELL_LISTS.get("Arcane Trickster")
+			or SPELL_LISTS.get("Wizard")
+			or {}
+			)
+		always = [MageHand] if getattr(trickster.character, "level", 1) >= 3 else []
+		cantrips, known = progressive_learn(
+			trickster.character,
+			source,
+			trickster.character.level,
+			cantrips_at=lambda lvl: stats_at_level(trickster, lvl, "cantrips"),
+			known_at=lambda lvl: stats_at_level(trickster, lvl, "prepared"),
+			slots_at=lambda lvl: stats_at_level(trickster, lvl, "slots"),
+			salt=CLASS_SALT["Arcane Trickster"],
+			always=always,
+			)
+		finish_learning(trickster, cantrips, known)
+		if getattr(trickster.character, "level", 1) >= 3:
+			grant_spell(trickster.character, MageHand)
 
 
 	def modifier(trickster):
@@ -1213,12 +1210,10 @@ class ArcaneTrickster(Spellcaster):
 		return (int_val - 10) // 2
 
 	def html(trickster):
-		return str(trickster)
+		return trickster.html_rules()
 
-	def __str__(trickster):
-		ordered_spells = sorted(trickster.spells_known, key=lambda s: int(s.level))
-		spells_names = "".join(f"<li>〖{spell.level}〗{spell.name}</li>" for spell in ordered_spells)
-		spells_html = "".join(f"""<div class="npc-textbox">{spell}</div>""" for spell in ordered_spells)
+	def html_rules(trickster):
+		index = html_spell_index(trickster, bullet="🎩")
 		slots = trickster.get_stats("slots")
 		slots_html = "<br>".join(f"<b>Level {lvl}</b>: <i>{num}</i> " for lvl, num in slots.items() if num > 0)
 		return f"""
@@ -1228,7 +1223,7 @@ class ArcaneTrickster(Spellcaster):
 				</div>
 			<div class="npc-textbox" style="grid-column: span 1;">
 				<h2>Spell Slots:</h2> {slots_html} <br>  You regain all expended slots when you finish a Long Rest.
-				<ul style="list-style-type: '🎩'; text-align: left; font-family: 'Iglesia';">{spells_names}</ul>
+				{index}
 				<h2>Arcane Focus</h2>
 				You can use an Arcane Focus (such as a wand or scepter), as a Spellcasting Focus for your Wizard spells.
 				</div>
@@ -1238,8 +1233,10 @@ class ArcaneTrickster(Spellcaster):
 			<div class="npc-textbox" style="margin-bottom: 1em;">
 				<h2 style="font-size:    1.35em;">Spell Attack Bonus:</h2> +{trickster.spell_attack_bonus()}
 				</div>
-			{spells_html}
 			"""
+
+	def __str__(trickster):
+		return trickster.html_rules()
 
 
 # Warlock spellcasting progression for 2024 PHB
@@ -1266,12 +1263,90 @@ WARLOCK_SPELLCASTING_TABLE = {
 		20: {"cantrips": 4, "prepared": 15, "slots": (4,),   "slot_level": 5},
 		}
 
+def genie_kind(character):
+	kind = getattr(character, "genie_kind", None)
+	if kind:
+		return kind
+	rng = caster_rng(character, 0x6E1)
+	kind = rng.choice(["Dao", "Djinni", "Efreeti", "Marid"])
+	character.genie_kind = kind
+	return kind
+
+
+def warlock_patron_spells(caster):
+	"""Always-prepared patron spells. Grows with level; never reshuffles."""
+	subclass = caster.character.subclass
+	level = caster.level
+	spells = []
+	if subclass == "Celestial":
+		if level >= 3: spells += [Aid, CureWounds, GuidingBolt, LesserRestoration, Light, SacredFlame]
+		if level >= 5: spells += [Daylight, Revivify]
+		if level >= 7: spells += [GuardianFaith, WallofFire]
+		if level >= 9: spells += [GreaterRestoration, SummonCelestial]
+	elif subclass == "Fiend":
+		if level >= 3: spells += [BurningHands, Command, ScorchingRay, Suggestion]
+		if level >= 5: spells += [Fireball, StinkingCloud]
+		if level >= 7: spells += [FireShield, WallofFire]
+		if level >= 9: spells += [Geas, InsectPlague]
+	elif subclass == "Great Old One":
+		if level >= 3: spells += [DetectThoughts, DissonantWhispers, PhantasmalForce, HideousLaughter]
+		if level >= 5: spells += [Clairvoyance, HungerHadar]
+		if level >= 7: spells += [Confusion, SummonAberration]
+		if level >= 9: spells += [ModifyMemory, Telekinesis]
+		if level >= 10: spells += [Hex]
+	elif subclass == "Genie":
+		if level >= 1: spells += [DetectEvilandGood]
+		if level >= 3: spells += [PhantasmalForce]
+		if level >= 5: spells += [CreateFoodWater]
+		if level >= 7: spells += [PhantasmalKiller]
+		if level >= 9: spells += [Creation]
+		if level >= 17: spells += [Wish]
+		patron = genie_kind(caster.character)
+		if patron == "Dao":
+			if level >= 1: spells += [Sanctuary]
+			if level >= 3: spells += [SpikeGrowth]
+			if level >= 5: spells += [MeldIntoStone]
+			if level >= 7: spells += [StoneShape]
+			if level >= 9: spells += [WallStone]
+		elif patron == "Djinni":
+			if level >= 1: spells += [Thunderwave]
+			if level >= 3: spells += [GustOfWind]
+			if level >= 5: spells += [WindWall]
+			if level >= 7: spells += [GreaterInvisibility]
+			if level >= 9: spells += [Seeming]
+		elif patron == "Efreeti":
+			if level >= 1: spells += [BurningHands]
+			if level >= 3: spells += [ScorchingRay]
+			if level >= 5: spells += [Fireball]
+			if level >= 7: spells += [FireShield]
+			if level >= 9: spells += [FlameStrike]
+		elif patron == "Marid":
+			if level >= 1: spells += [FogCloud]
+			if level >= 3: spells += [Blur]
+			if level >= 5: spells += [SleetStorm]
+			if level >= 7: spells += [ControlWater]
+			if level >= 9: spells += [ConeofCold]
+	elif subclass == "Archfey":
+		if level >= 3: spells += [CalmEmotions, FaerieFire, MistyStep, PhantasmalForce, Sleep]
+		if level >= 5: spells += [Blink, PlantGrowth]
+		if level >= 7: spells += [DominateBeast, GreaterInvisibility]
+		if level >= 9: spells += [DominatePerson, Seeming]
+	if level >= 9:
+		spells += [ContactOtherPlane]
+	return unique_spells(spells)
+
+
 class Warlock(Spellcaster):
 	def __init__(caster, character,known=None):
 		if known is None:     known = []
 		caster.class_name     = "Warlock"
 		caster.character     = character
 		caster.level         = character.level
+		caster.granted_spells = []
+		caster.always_prepared = set()
+		caster.prepared_spells = []
+		caster.catalog_known = True
+		caster.mystic_arcanum = []
 		caster.spell_slots     = caster.get_spell_slots()
 		caster.spells_available = caster.available_spells()
 		caster.spells_known = known
@@ -1308,103 +1383,44 @@ class Warlock(Spellcaster):
 		return spells
 
 	def prepare_spells(caster):
-		# 1) Pact‐spells
-		n = caster.get_stats("prepared")
-		# Warlocks can change prepared spells on level-up/long rest
-		available = caster.available_spells()
-		# Random for demo; in-app, let user select!
-		chosen = random.sample(available, min(n, len(available)))
-
-		# 2) Cantrips
-		cantrip_pool = [s for s in available if int(s.level) == 0]
-		cantrips = random.sample(cantrip_pool, min(len(cantrip_pool), caster.get_stats("cantrips")))
-
-		caster.spells_known = cantrips + [s for s in chosen if int(s.level) > 0]
-		if caster.character.subclass == "Celestial":
-			if caster.level >= 3: caster.spells_known += [Aid, CureWounds,    GuidingBolt, LesserRestoration, Light, SacredFlame]
-			if caster.level >= 5: caster.spells_known += [Daylight, Revivify]
-			if caster.level >= 7: caster.spells_known += [GuardianFaith, WallofFire]
-			if caster.level >= 9: caster.spells_known += [GreaterRestoration, SummonCelestial]
-		if caster.character.subclass == "Fiend":
-			if caster.level >= 3: caster.spells_known += [BurningHands,    Command,    ScorchingRay,    Suggestion]
-			if caster.level >= 5: caster.spells_known += [Fireball, StinkingCloud]
-			if caster.level >= 7: caster.spells_known += [FireShield, WallofFire]
-			if caster.level >= 9: caster.spells_known += [Geas,    InsectPlague]
-		if caster.character.subclass == "Great Old One":
-			if caster.level >= 3: caster.spells_known += [DetectThoughts,    DissonantWhispers,    PhantasmalForce,    HideousLaughter]
-			if caster.level >= 5: caster.spells_known += [Clairvoyance, HungerHadar]
-			if caster.level >= 7: caster.spells_known += [Confusion,    SummonAberration]
-			if caster.level >= 10: caster.spells_known += [Hex]
-			if caster.level >= 9: caster.spells_known += [ModifyMemory,    Telekinesis]
-		if caster.character.subclass == "Genie":
-			if caster.level >= 1: caster.spells_known += [DetectEvilandGood]
-			if caster.level >= 3: caster.spells_known += [PhantasmalForce]
-			if caster.level >= 5: caster.spells_known += [CreateFoodWater]
-			if caster.level >= 7: caster.spells_known += [PhantasmalKiller]
-			if caster.level >= 9: caster.spells_known += [Creation]
-			if caster.level >= 17: caster.spells_known += [Wish]
-			random.seed(caster.character.seed)
-			patron = random.choice([
-				"Dao", "Djinni", "Efreeti", "Marid"
-				])
-			if patron == "Dao":
-				if caster.level >= 1: caster.spells_known += [sanctuary]
-				if caster.level >= 3: caster.spells_known += [SpikeGrowth]
-				if caster.level >= 5: caster.spells_known += [MeldIntoStone]
-				if caster.level >= 7: caster.spells_known += [StoneShape]
-				if caster.level >= 9: caster.spells_known += [WallStone]
-			if patron == "Djinni":
-				if caster.level >= 1: caster.spells_known += [Thunderwave]
-				if caster.level >= 3: caster.spells_known += [GustOfWind]
-				if caster.level >= 5: caster.spells_known += [WindWall]
-				if caster.level >= 7: caster.spells_known += [GreaterInvisibility]
-				if caster.level >= 9: caster.spells_known += [Seeming]
-			if patron == "Efreeti":
-				if caster.level >= 1: caster.spells_known += [BurningHands]
-				if caster.level >= 3: caster.spells_known += [ScorchingRay]
-				if caster.level >= 5: caster.spells_known += [Fireball]
-				if caster.level >= 7: caster.spells_known += [FireShield]
-				if caster.level >= 9: caster.spells_known += [FlameStrike]
-			if patron == "Marid":
-				if caster.level >= 1: caster.spells_known += [FogCloud]
-				if caster.level >= 3: caster.spells_known += [Blur]
-				if caster.level >= 5: caster.spells_known += [SleetStorm]
-				if caster.level >= 7: caster.spells_known += [ControlWater]
-				if caster.level >= 9: caster.spells_known += [ConeofCold]
-		if caster.character.subclass == "Archfey":
-			if caster.level >= 3: caster.spells_known += [CalmEmotions, FaerieFire, MistyStep, PhantasmalForce, Sleep]
-			if caster.level >= 5: caster.spells_known += [Blink, PlantGrowth]
-			if caster.level >= 7: caster.spells_known += [DominateBeast, GreaterInvisibility]
-			if caster.level >= 9: caster.spells_known += [DominatePerson,    Seeming]
-		if caster.level >= 9: caster.spells_known += [ContactOtherPlane]
-
-
-		# 3) Mystic Arcanum — one per slot-level at these thresholds:
+		table = SPELL_LISTS.get("Warlock", {})
+		cantrips, known = progressive_learn(
+			caster.character,
+			table,
+			caster.level,
+			cantrips_at=lambda lvl: stats_at_level(caster, lvl, "cantrips"),
+			known_at=lambda lvl: stats_at_level(caster, lvl, "prepared"),
+			slots_at=lambda lvl: stats_at_level(caster, lvl, "slots"),
+			salt=CLASS_SALT["Warlock"],
+			)
+		finish_learning(caster, cantrips, known)
+		for spell in warlock_patron_spells(caster):
+			grant_spell(caster.character, spell)
+		# Mystic Arcanum — one per slot-level, stable as the warlock levels
 		caster.mystic_arcanum = []
 		arcanum_requirements = {6: 11, 7: 13, 8: 15, 9: 17}
-		warlock_table = SPELL_LISTS.get(caster.character.char_class, {})
-		for lvl, req_level in arcanum_requirements.items():
+		rng = caster_rng(caster.character, 0xA0C ^ CLASS_SALT["Warlock"])
+		already = {spell_key(spell) for spell in catalog_spells(caster)}
+		for spell_lvl, req_level in arcanum_requirements.items():
 			if caster.level >= req_level:
-				pool = warlock_table.get(lvl, [])
-				if pool:
-					caster.mystic_arcanum.append(random.choice(pool))
+				pool = table.get(spell_lvl, [])
+				added = pick_new(pool, 1, rng, already)
+				for spell in added:
+					caster.mystic_arcanum.append(spell)
+					grant_spell(caster.character, spell)
+					already.add(spell_key(spell))
 
 	def modifier(caster):
 		# CHA-based, so use character abilities
 		return (getattr(caster.character.AS, caster.casting_stat) - 10) // 2
 
 	def html(caster):
-		# simply delegate to __str__, which you’ve already written
-		return str(caster)
+		return caster.html_rules()
 
-	def __str__(caster):
-		cantrips = [s for s in caster.spells_known if int(s.level) == 0]
-		leveled = [s for s in caster.spells_known if int(s.level) > 0]
+	def html_rules(caster):
 		n_prep = caster.get_stats("prepared")
 		arcanums   = getattr(caster, "mystic_arcanum", [])
-
-		spell_list = "".join(f"<li>【{s.level}】{s.name}</li>" for s in cantrips + leveled)
-		spells_html = "".join(f"""<div class="npc-textbox">{s}</div>""" for s in cantrips + leveled)
+		index = html_spell_index(caster, bullet="🔮")
 
 		slots = caster.get_stats("slots")
 		slot_level = caster.get_stats("slot_level")
@@ -1421,7 +1437,7 @@ class Warlock(Spellcaster):
 		slot_str += "</h2>"
 
 		if arcanums:
-			lis = "".join(f"<li>【{s.level}】{s.name}</li>" for s in arcanums)
+			lis = "".join(f"<li>{spell_mark(s)}</li>" for s in arcanums)
 			arcanum = f"""
 				<div class="npc-textbox" style="grid-column: span 1;">
 					<h2 style="font-family: 'Iglesia'; font-size: 2.1em;">Mystic Arcanum</h2>
@@ -1455,16 +1471,16 @@ class Warlock(Spellcaster):
 		<div class="npc-textbox" style="grid-column: span 1;">
 			<h3 style="font-family: 'Iglesia'; font-size: 2.1em;">Prepared Spells</h3>
 			You prepare {n_prep} warlock spells at the end of each long rest. Each must be of a level you can cast.<br>
-			<ul style="list-style-type: '🔮'; text-align: left; font-family: 'Iglesia'">
-				{spell_list}
-			</ul>
+			{index}
 			<h3 style="font-family: 'Iglesia'; font-size: 2.1em;">Cantrips</h3>
 			You always know {caster.get_stats("cantrips")} cantrips from the warlock list.<br>
 		</div>
 
 		{arcanum}
-		{spells_html}
 		"""
+
+	def __str__(caster):
+		return caster.html_rules()
 
 # Factory to get the appropriate class
 def spellcaster(character):

--- a/AtlasLusoris/Grimoire_of_Spellcasters.py
+++ b/AtlasLusoris/Grimoire_of_Spellcasters.py
@@ -621,16 +621,15 @@ class Wizard(Spellcaster):
 			<div class="npc-textbox" style="grid-column: span 3;">
 				<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">
 					The Book of Names</h1>
-				<p>You do not invent magic. You hunt True Names, write them,
-				and speak them when the world will answer. To know the name
-				is to understand the thing — and to understand it is to
-				connect with it. Intelligence is the voice you use.</p>
+				<p>Wonder happens on the road. The book is how you carry it.
+				You hunt names, write them, and speak them when the world
+				will answer. Intelligence is the voice you use.</p>
 				</div>
 			<div class="npc-textbox" style="grid-column: span 1;">
 				<h2>Spell Slots:</h2>
 				{slots_html} <br>
 				You regain all expended slots when you finish a Long Rest.
-				A slot is a name spoken with enough breath to wake it.</p>
+				</p>
 				<br><br>
 				</div>
 			<div class="npc-textbox" style="font-family: 'Iglesia'">
@@ -641,14 +640,13 @@ class Wizard(Spellcaster):
 				</div>
 			<div class="npc-textbox" style="grid-column: span 1;">
 			<h3 style="font-family: 'Iglesia'; font-size:    3.1em; "> Spellbook </h3>
-			When you finish a Long Rest, you may prepare {n} names from the
+			When you finish a Long Rest, you may prepare {n} spells from the
 			book — the ones you can speak at any moment. 【prepared】
 			〖written, not prepared〗
 			{index}
 			<h2>Arcane Focus</h2>
-			You can use an Arcane Focus (wand, scepter, orb, staff) as a
-			Spellcasting Focus for your Wizard spells — a tool for aiming
-			a name without shouting it into bare air.
+			You can use an Arcane Focus as a Spellcasting Focus for your
+			Wizard spells.
 			</div>
 			"""
 

--- a/AtlasLusoris/Grimoire_of_Spellcasters.py
+++ b/AtlasLusoris/Grimoire_of_Spellcasters.py
@@ -559,18 +559,23 @@ class Wizard(Spellcaster):
 
 	def __str__(caster):
 		n = caster.get_stats("spells")
-		cantrips = [s for s in caster.spells_known if s.level == 0]
-		other_spells = [s for s in caster.spells_known if s.level > 0]
+		def spell_level(spell):
+			try:
+				return int(spell.level)
+			except (TypeError, ValueError):
+				return 0
+		cantrips = [s for s in caster.spells_known if spell_level(s) == 0]
+		other_spells = [s for s in caster.spells_known if spell_level(s) > 0]
 
 		random.shuffle(other_spells)
 		prepared = other_spells[:n]
 		unprepared = other_spells[n:]
-		all_spells = sorted(prepared + unprepared, key=lambda s: (s.level, s.name))
+		all_spells = sorted(prepared + unprepared, key=lambda s: (spell_level(s), s.name))
 		spells = ""
 		for spell in cantrips:
 			spells += f"<li>【{spell.level}】{spell.name}</li>"
 		for spell in all_spells:
-			if spell in prepared or spell.level==0:
+			if spell in prepared or spell_level(spell)==0:
 				spells += f"<li>【{spell.level}】{spell.name}</li>"
 			else:
 				spells += f"<li>〖{spell.level}〗{spell.name}</li>"
@@ -590,13 +595,17 @@ class Wizard(Spellcaster):
 		return f"""
 			<div class="npc-textbox" style="grid-column: span 3;">
 				<h1 style="font-family: 'Iglesia'; font-size:    3.1em; ">
-					Wizard Spellcasting</h1>
-				<p> As a student of arcane magic, you have learned to cast spells. </p>
+					The Book of Names</h1>
+				<p>You do not invent magic. You hunt True Names, write them,
+				and speak them when the world will answer. To know the name
+				is to understand the thing — and to understand it is to
+				connect with it. Intelligence is the voice you use.</p>
 				</div>
 			<div class="npc-textbox" style="grid-column: span 1;">
 				<h2>Spell Slots:</h2>
 				{slots_html} <br>
-				You regain all expended slots when you finish a Long Rest.</p>
+				You regain all expended slots when you finish a Long Rest.
+				A slot is a name spoken with enough breath to wake it.</p>
 				<br><br>
 				</div>
 			<div class="npc-textbox" style="font-family: 'Iglesia'">
@@ -606,12 +615,16 @@ class Wizard(Spellcaster):
 					Spell Attack Bonus:</h2> +{caster.spell_attack_bonus()}
 				</div>
 			<div class="npc-textbox" style="grid-column: span 1;">
-			<h3 style="font-family: 'Iglesia'; font-size:    3.1em; "> SpellBook </h3>
-			You may prepare {n} spells whenever you finish a Long Rest, that you can use at any moment, from your book of spells:
+			<h3 style="font-family: 'Iglesia'; font-size:    3.1em; "> Spellbook </h3>
+			When you finish a Long Rest, you may prepare {n} names from the
+			book — the ones you can speak at any moment. 【prepared】
+			〖written, not prepared〗
 			<ul style="list-style-type: '🪄'; text-align: left; font-family: 'Iglesia' ">
 				{spells}</ul>
 			<h2>Arcane Focus</h2>
-			You can use an Arcane Focus (such as a wand or scepter),  as a Spellcasting Focus for your Wizard spells.
+			You can use an Arcane Focus (wand, scepter, orb, staff) as a
+			Spellcasting Focus for your Wizard spells — a tool for aiming
+			a name without shouting it into bare air.
 			</div>
 			{spells_html}
 			"""

--- a/AtlasLusoris/Map_of_Backgrounds.py
+++ b/AtlasLusoris/Map_of_Backgrounds.py
@@ -15,6 +15,7 @@ from AtlasLusoris.Grimoire_of_Features import (
 		MagicInitiateWizard,
 		TavernBrawler,
 		SavageAttacker,
+		Wildwarden,
 		)
 # Weighted table
 backgrounds = [
@@ -34,6 +35,7 @@ backgrounds = [
 				"Scribe",
 				"Soldier",
 				"Wayfarer",
+				"Wildkeeper",
 				]
 
 BACKGROUND_FEATURES = {
@@ -133,6 +135,12 @@ BACKGROUND_FEATURES = {
 		source="Background",
 		level=1,
 		),
+	"Wildkeeper": Feature(
+		name="Edge of the Wild",
+		description="You know the paths animals use around settlements, and they know you. Folk come to you when something in the woods will not leave them alone — or when they have gone too far in.",
+		source="Background",
+		level=1,
+		),
 	}
 
 def background_features(name: str):
@@ -159,6 +167,7 @@ def ApplyBackground(char):
 		TavernBrawler,
 		SavageAttacker,
 		Lucky,
+		Wildwarden,
 		)
 	base_feats = []
 	background_name: str = getattr(char, "background", None)
@@ -184,6 +193,7 @@ def ApplyBackground(char):
 		"Scribe": SkilledFeat,
 		"Soldier": SavageAttacker,
 		"Wayfarer": Lucky,
+		"Wildkeeper": Wildwarden,
 		}
 
 	# Apply each narrative feature.

--- a/AtlasLusoris/Map_of_Casting_Tables.py
+++ b/AtlasLusoris/Map_of_Casting_Tables.py
@@ -1,0 +1,138 @@
+"""2024 PHB spellcasting columns, one table per class.
+
+Lists of spells stay in Grimoire_of_Spellcasters. These rows are only
+cantrips, prepared counts, and slots. Same shape, class as the key —
+so a new caster is a table, not a new get_stats method.
+"""
+
+# Full casters share this slot column except Druid from 18 up.
+_FULL_SLOTS = {
+	1:  (2, 0, 0, 0, 0, 0, 0, 0, 0),
+	2:  (3, 0, 0, 0, 0, 0, 0, 0, 0),
+	3:  (4, 2, 0, 0, 0, 0, 0, 0, 0),
+	4:  (4, 3, 0, 0, 0, 0, 0, 0, 0),
+	5:  (4, 3, 2, 0, 0, 0, 0, 0, 0),
+	6:  (4, 3, 3, 0, 0, 0, 0, 0, 0),
+	7:  (4, 3, 3, 1, 0, 0, 0, 0, 0),
+	8:  (4, 3, 3, 2, 0, 0, 0, 0, 0),
+	9:  (4, 3, 3, 3, 1, 0, 0, 0, 0),
+	10: (4, 3, 3, 3, 2, 0, 0, 0, 0),
+	11: (4, 3, 3, 3, 2, 1, 0, 0, 0),
+	12: (4, 3, 3, 3, 2, 1, 0, 0, 0),
+	13: (4, 3, 3, 3, 2, 1, 1, 0, 0),
+	14: (4, 3, 3, 3, 2, 1, 1, 0, 0),
+	15: (4, 3, 3, 3, 2, 1, 1, 1, 0),
+	16: (4, 3, 3, 3, 2, 1, 1, 1, 0),
+	17: (4, 3, 3, 3, 2, 1, 1, 1, 1),
+	18: (4, 3, 3, 3, 3, 1, 1, 1, 1),
+	19: (4, 3, 3, 3, 3, 2, 1, 1, 1),
+	20: (4, 3, 3, 3, 3, 2, 2, 1, 1),
+	}
+
+# Druid 18–20: two 5th-level slots, not three; 18 has one 6th, 20 has two 6th.
+_DRUID_SLOTS = dict(_FULL_SLOTS)
+_DRUID_SLOTS[18] = (4, 3, 3, 3, 2, 1, 1, 1, 1)
+_DRUID_SLOTS[19] = (4, 3, 3, 3, 2, 1, 1, 1, 1)
+_DRUID_SLOTS[20] = (4, 3, 3, 3, 2, 2, 1, 1, 1)
+
+
+def _full(cantrips, prepared, slots=_FULL_SLOTS):
+	return {
+		lvl: {
+			"cantrips": cantrips[lvl],
+			"prepared": prepared[lvl],
+			"slots": slots[lvl],
+			}
+		for lvl in range(1, 21)
+		}
+
+
+# Wizard: 3 cantrips, +1 at 4 and 10. Prepared 4…25.
+_WIZARD_CANTRIPS = {lvl: 3 if lvl < 4 else 4 if lvl < 10 else 5 for lvl in range(1, 21)}
+_WIZARD_PREPARED = {
+	1: 4, 2: 5, 3: 6, 4: 7, 5: 9, 6: 10, 7: 11, 8: 12, 9: 14, 10: 15,
+	11: 16, 12: 16, 13: 17, 14: 18, 15: 19, 16: 21, 17: 22, 18: 23, 19: 24, 20: 25,
+	}
+
+# Sorcerer: 4 cantrips, +1 at 4 and 10. Prepared starts at 2.
+_SORCERER_CANTRIPS = {lvl: 4 if lvl < 4 else 5 if lvl < 10 else 6 for lvl in range(1, 21)}
+_SORCERER_PREPARED = {
+	1: 2, 2: 4, 3: 6, 4: 7, 5: 9, 6: 10, 7: 11, 8: 12, 9: 14, 10: 15,
+	11: 16, 12: 16, 13: 17, 14: 17, 15: 18, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+	}
+
+# Druid: 2 cantrips, +1 at 4 and 10. Prepared 4…22.
+_DRUID_CANTRIPS = {lvl: 2 if lvl < 4 else 3 if lvl < 10 else 4 for lvl in range(1, 21)}
+_DRUID_PREPARED = {
+	1: 4, 2: 5, 3: 6, 4: 7, 5: 9, 6: 10, 7: 11, 8: 12, 9: 14, 10: 15,
+	11: 16, 12: 16, 13: 17, 14: 17, 15: 18, 16: 18, 17: 19, 18: 20, 19: 21, 20: 22,
+	}
+
+CASTING = {
+	"Wizard": _full(_WIZARD_CANTRIPS, _WIZARD_PREPARED),
+	"Sorcerer": _full(_SORCERER_CANTRIPS, _SORCERER_PREPARED),
+	"Druid": _full(_DRUID_CANTRIPS, _DRUID_PREPARED, _DRUID_SLOTS),
+	"Ranger": {
+		1:  {"prepared": 2,  "slots": (2, 0, 0, 0, 0)},
+		2:  {"prepared": 3,  "slots": (2, 0, 0, 0, 0)},
+		3:  {"prepared": 4,  "slots": (3, 0, 0, 0, 0)},
+		4:  {"prepared": 5,  "slots": (3, 0, 0, 0, 0)},
+		5:  {"prepared": 6,  "slots": (4, 2, 0, 0, 0)},
+		6:  {"prepared": 6,  "slots": (4, 2, 0, 0, 0)},
+		7:  {"prepared": 7,  "slots": (4, 3, 0, 0, 0)},
+		8:  {"prepared": 7,  "slots": (4, 3, 0, 0, 0)},
+		9:  {"prepared": 8,  "slots": (4, 3, 2, 0, 0)},
+		10: {"prepared": 8,  "slots": (4, 3, 2, 0, 0)},
+		11: {"prepared": 10, "slots": (4, 3, 3, 0, 0)},
+		12: {"prepared": 10, "slots": (4, 3, 3, 0, 0)},
+		13: {"prepared": 11, "slots": (4, 3, 3, 1, 0)},
+		14: {"prepared": 11, "slots": (4, 3, 3, 1, 0)},
+		15: {"prepared": 12, "slots": (4, 3, 3, 2, 0)},
+		16: {"prepared": 12, "slots": (4, 3, 3, 2, 0)},
+		17: {"prepared": 14, "slots": (4, 3, 3, 3, 1)},
+		18: {"prepared": 14, "slots": (4, 3, 3, 3, 1)},
+		19: {"prepared": 15, "slots": (4, 3, 3, 3, 2)},
+		20: {"prepared": 15, "slots": (4, 3, 3, 3, 2)},
+		},
+	"Warlock": {
+		1:  {"cantrips": 2, "prepared": 2,  "slots": 1, "slot_level": 1},
+		2:  {"cantrips": 2, "prepared": 3,  "slots": 2, "slot_level": 1},
+		3:  {"cantrips": 2, "prepared": 4,  "slots": 2, "slot_level": 2},
+		4:  {"cantrips": 3, "prepared": 5,  "slots": 2, "slot_level": 2},
+		5:  {"cantrips": 3, "prepared": 6,  "slots": 2, "slot_level": 3},
+		6:  {"cantrips": 3, "prepared": 7,  "slots": 2, "slot_level": 3},
+		7:  {"cantrips": 3, "prepared": 8,  "slots": 2, "slot_level": 4},
+		8:  {"cantrips": 3, "prepared": 9,  "slots": 2, "slot_level": 4},
+		9:  {"cantrips": 3, "prepared": 10, "slots": 2, "slot_level": 5},
+		10: {"cantrips": 4, "prepared": 10, "slots": 2, "slot_level": 5},
+		11: {"cantrips": 4, "prepared": 11, "slots": 3, "slot_level": 5},
+		12: {"cantrips": 4, "prepared": 11, "slots": 3, "slot_level": 5},
+		13: {"cantrips": 4, "prepared": 12, "slots": 3, "slot_level": 5},
+		14: {"cantrips": 4, "prepared": 12, "slots": 3, "slot_level": 5},
+		15: {"cantrips": 4, "prepared": 13, "slots": 3, "slot_level": 5},
+		16: {"cantrips": 4, "prepared": 13, "slots": 3, "slot_level": 5},
+		17: {"cantrips": 4, "prepared": 14, "slots": 4, "slot_level": 5},
+		18: {"cantrips": 4, "prepared": 14, "slots": 4, "slot_level": 5},
+		19: {"cantrips": 4, "prepared": 15, "slots": 4, "slot_level": 5},
+		20: {"cantrips": 4, "prepared": 15, "slots": 4, "slot_level": 5},
+		},
+	}
+
+# Empty class lists inherit another list until tagged per-spell lists exist.
+LIST_FALLBACK = {
+	"Sorcerer": "Wizard",
+	}
+
+
+def casting_row(class_name, level):
+	table = CASTING.get(class_name) or {}
+	lvl = min(max(int(level or 1), 1), 20)
+	return table.get(lvl) or table.get(20) or {}
+
+
+def slots_as_map(slots):
+	if isinstance(slots, dict):
+		return {lvl: n for lvl, n in slots.items() if n}
+	if isinstance(slots, (tuple, list)):
+		return {i + 1: n for i, n in enumerate(slots) if n}
+	return {}

--- a/AtlasLusoris/Map_of_Classes/Codex_of_Progression.py
+++ b/AtlasLusoris/Map_of_Classes/Codex_of_Progression.py
@@ -21,25 +21,20 @@ def get_class_progression(character):
 	Return a Progression instance bound to this character.
 	"""
 	class_name = character.character_class
-	from .  import (  # local import avoids circulars during top-level load
-			Barbarian, Bard, Cleric, Druid, Fighter, Monk,
-			Paladin, Ranger, Rogue, Sorcerer, Warlock, Wizard
-			)
-	mapping = {
-		"Fighter": 	Fighter,
-		"Wizard":  	Wizard,
-		"Barbarian": Barbarian,
-		"Rogue": 	Rogue,
-		"Paladin": 	Paladin,
-		"Bard": 	Bard,
-		"Druid": 	Druid,
-		'Warlock': 	Warlock,
-		'Monk': 	Monk,
-		'Ranger': 	Ranger,
-		'Sorcerer': 	Sorcerer,
-		# Artificer?
-		}
+	import importlib
+	mapping = {}
+	for name in (
+			"Fighter", "Wizard", "Barbarian", "Rogue", "Paladin",
+			"Bard", "Druid", "Warlock", "Monk", "Ranger", "Sorcerer",
+			):
+		try:
+			module = importlib.import_module(f".Training.{name}", __package__)
+			mapping[name] = getattr(module, name)
+		except Exception:
+			continue
 	prog_cls = mapping.get(class_name)
+	if prog_cls is None:
+		return None
 	return prog_cls(character)
 
 def GetFeatures(character) -> List[Feature]:
@@ -103,7 +98,7 @@ def apply_class_proficiencies(character):
 								name="Spellbook",
 								value=50,
 								weight=3,
-								description="Arcane writings",
+								description="A book of True Names, readable only by you",
 								)
 						equip.buy_item(book)
 	elif cls == "Rogue":

--- a/AtlasLusoris/Map_of_Classes/Codex_of_Progression.py
+++ b/AtlasLusoris/Map_of_Classes/Codex_of_Progression.py
@@ -94,11 +94,14 @@ def apply_class_proficiencies(character):
 						equip.buy_item(staff)
 						equip.equip_right(staff)
 
+						book_line = "A spellbook, readable only by you"
+						if getattr(character, "wizard_book", None):
+							book_line = character.wizard_book.get("line", book_line)
 						book = Object(
 								name="Spellbook",
 								value=50,
 								weight=3,
-								description="A book of True Names, readable only by you",
+								description=book_line,
 								)
 						equip.buy_item(book)
 	elif cls == "Rogue":

--- a/AtlasLusoris/Map_of_Classes/Scroll_of_Constants.py
+++ b/AtlasLusoris/Map_of_Classes/Scroll_of_Constants.py
@@ -15,6 +15,7 @@ def subclasses():
 		"Champion", "Battle Master", "Eldritch Knight", "Samurai"],
 	'Wizard': [
 		"Evoker", "Illusionist", "Necromancer", "Diviner", "Abjurer",
+		"Bladesinger",
 		],
 	'Rogue': [
 		"Assassin",	 "Arcane Trickster", "Thief", "Swashbuckler",	],

--- a/AtlasLusoris/Map_of_Classes/Scroll_of_Constants.py
+++ b/AtlasLusoris/Map_of_Classes/Scroll_of_Constants.py
@@ -14,8 +14,7 @@ def subclasses():
 	'Fighter': [
 		"Champion", "Battle Master", "Eldritch Knight", "Samurai"],
 	'Wizard': [
-		"Evoker", "Illusion", "Necromancy", "Divination",
-		"Abjuration",
+		"Evoker", "Illusionist", "Necromancer", "Diviner", "Abjurer",
 		],
 	'Rogue': [
 		"Assassin",	 "Arcane Trickster", "Thief", "Swashbuckler",	],

--- a/AtlasLusoris/Map_of_Classes/Training/Druid.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Druid.py
@@ -21,7 +21,7 @@ class Druid(Progression):
 
 			if random.choice([True,False]):
 				from AtlasLusoris.Compass_of_Learned_Spells import (
-					caster_rng, grant_spell, pick_new, spell_key, spell_mark,
+					caster_rng, know_spell, pick_new, spell_key, spell_mark,
 					)
 				from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
 				already = set()
@@ -36,9 +36,7 @@ class Druid(Progression):
 					)
 				extra_line = ""
 				for spell in extra:
-					grant_spell(character, spell)
-					if caster is not None and getattr(caster, "spells_known", None) is not None:
-						caster.spells_known.append(spell)
+					know_spell(character, spell)
 					extra_line = f" Extra cantrip: {spell_mark(spell)}. See Spells."
 				feats.append(Feature("Primal Order: Magician",
 					f"""You learnt one extra cantrip.{extra_line}
@@ -60,13 +58,14 @@ class Druid(Progression):
 				character.Primal_Order = "Warden"
 
 		if level >= 2:
+			from AtlasMagia.Lodge_of_Spells import FindFamiliar
+			from AtlasLusoris.Compass_of_Learned_Spells import know_spell, spell_mark
+			know_spell(character, FindFamiliar)
 			feats.append(Feature("Wild Companion",
 				f"""You can summon a nature spirit that assumes an animal form to aid you.
 				As a Magic action, you can expend a spell slot or a use of Wild Shape
-				to cast the <i>Find Familiar</i> spell without Material components. <br>
-				<br>
-				When you cast the spell in this way, the familiar is Fey and
-				disappears when you finish a Long Rest. """,
+				to cast {spell_mark(FindFamiliar)} without Material components.
+				When you cast it this way, the familiar is Fey and disappears when you finish a Long Rest. See Spells.""",
 				"Class: Druid"))
 
 			uses = 2 + (1 if level >= 6 else 0) + (1 if level >= 17 else 0)

--- a/AtlasLusoris/Map_of_Classes/Training/Druid.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Druid.py
@@ -45,8 +45,11 @@ class Druid(Progression):
 					Your Wisdom modifier (min +1) is added to Arcana or Nature checks.""",
 					"Class: Druid"))
 				character.Primal_Order = "Magician"
-				character.abilities.Nature += max(1,character.AS.WIS)
-				character.abilities.Arcana += max(1,character.AS.WIS)
+				try:
+					character.abilities.Nature += max(1,character.AS.WIS)
+					character.abilities.Arcana += max(1,character.AS.WIS)
+				except Exception:
+					pass
 
 			else:
 				feats.append(Feature("Primal Order: Warden",

--- a/AtlasLusoris/Map_of_Classes/Training/Druid.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Druid.py
@@ -20,8 +20,28 @@ class Druid(Progression):
 		if level >= 1:
 
 			if random.choice([True,False]):
+				from AtlasLusoris.Compass_of_Learned_Spells import (
+					caster_rng, grant_spell, pick_new, spell_key, spell_mark,
+					)
+				from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
+				already = set()
+				caster = getattr(character, "spellcaster", None)
+				if caster is not None:
+					already = {spell_key(spell) for spell in getattr(caster, "spells_known", []) or []}
+				extra = pick_new(
+					SPELL_LISTS.get("Druid", {}).get(0, []),
+					1,
+					caster_rng(character, 0xD01),
+					already,
+					)
+				extra_line = ""
+				for spell in extra:
+					grant_spell(character, spell)
+					if caster is not None and getattr(caster, "spells_known", None) is not None:
+						caster.spells_known.append(spell)
+					extra_line = f" Extra cantrip: {spell_mark(spell)}. See Spells."
 				feats.append(Feature("Primal Order: Magician",
-					"""You learnt one extra cantrip.
+					f"""You learnt one extra cantrip.{extra_line}
 					Your Wisdom modifier (min +1) is added to Arcana or Nature checks.""",
 					"Class: Druid"))
 				character.Primal_Order = "Magician"

--- a/AtlasLusoris/Map_of_Classes/Training/Druid.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Druid.py
@@ -21,13 +21,10 @@ class Druid(Progression):
 
 			if random.choice([True,False]):
 				from AtlasLusoris.Compass_of_Learned_Spells import (
-					caster_rng, know_spell, pick_new, spell_key, spell_mark,
+					catalog_keys, caster_rng, know_spell, pick_new, spell_mark,
 					)
 				from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
-				already = set()
-				caster = getattr(character, "spellcaster", None)
-				if caster is not None:
-					already = {spell_key(spell) for spell in getattr(caster, "spells_known", []) or []}
+				already = catalog_keys(getattr(character, "spellcaster", None))
 				extra = pick_new(
 					SPELL_LISTS.get("Druid", {}).get(0, []),
 					1,

--- a/AtlasLusoris/Map_of_Classes/Training/Fighter.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Fighter.py
@@ -1,7 +1,7 @@
 from ..Grimoire_of_Health  import roll_health, HIT_DIE_TABLE
 from ..Codex_of_Progression import Progression
 
-from AtlasLusoris.Grimoire_of_Features import Feature, add_new_fighting_style
+from AtlasLusoris.Grimoire_of_Features import Feature, add_new_fighting_style, ApplyRandomFeats, ApplyEpicBoon
 
 
 class Fighter(Progression):

--- a/AtlasLusoris/Map_of_Classes/Training/Monk.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Monk.py
@@ -274,6 +274,9 @@ class Shadow(Way):
 		# Level 3 features
 		if level >= 3:
 			from AtlasMagia.Lodge_of_Spells import Darkness, MinorIllusion
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+			grant_spell(character, Darkness)
+			grant_spell(character, MinorIllusion)
 			feats.append(Feature("Warrior of Shadow",
 				"""
 				Warriors of Shadow practice stealth and subterfuge, harnessing the power of the Shadowfell. They are at home in darkness, able to draw gloom around themselves to hide, leap from shadow to shadow, and take on a wraithlike form.
@@ -281,13 +284,12 @@ class Shadow(Way):
 
 			feats.append(Feature("Shadow Arts: Darkness. ",
 				f"""
-				You can expend 1 Focus Point to cast the Darkness spell
+				You can expend 1 Focus Point to cast {spell_mark(Darkness)}
 				without spell components. You can see within the spell's
 				area when you cast it with this feature. While the spell
 				persists, you can move its area of Darkness to a space
 				within 60 feet of yourself at the start of each of your
-				turns.
-				<div class="npc-textbox">{Darkness}</div>
+				turns. See Spells.
 				"""))
 			feats.append(Feature("Shadow Arts: Darkvision. ",
 				"""
@@ -296,9 +298,8 @@ class Shadow(Way):
 				"""))
 			feats.append(Feature("Shadow Arts: Shadowy Figments. ",
 				f"""
-				You know the Minor Illusion spell.
-				Wisdom is your spellcasting ability for it.
-				<div class="npc-textbox">{MinorIllusion}</div>
+				You know {spell_mark(MinorIllusion)}.
+				Wisdom is your spellcasting ability for it. See Spells.
 				"""))
 
 		# Level 6 features
@@ -370,6 +371,8 @@ class Elements(Way):
 		# Level 3 features
 		if level >= 3:
 			from AtlasMagia.Lodge_of_Spells import Elementalism
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+			grant_spell(character, Elementalism)
 			feats.append(Feature("Warrior of the Elements",
 				"""
 				Warriors of the Elements tap into the power of the
@@ -388,8 +391,7 @@ class Elements(Way):
 				"""))
 			feats.append(Feature("Manipulate Elements",
 				f"""
-				You know the Elementalism spell. Wisdom is your spellcasting ability for it.
-				<div class="npc-textbox">{Elementalism}</div>
+				You know {spell_mark(Elementalism)}. Wisdom is your spellcasting ability for it. See Spells.
 				"""))
 		# Level 6 features
 		if level >= 6:

--- a/AtlasLusoris/Map_of_Classes/Training/Ranger.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Ranger.py
@@ -1,6 +1,15 @@
 from ..Grimoire_of_Health  import roll_health, HIT_DIE_TABLE
 from ..Codex_of_Progression import Progression
 
+from AtlasLusoris.Grimoire_of_Features import (
+	Feature,
+	add_new_fighting_style,
+	ApplyRandomFeats,
+	ApplyEpicBoon,
+	)
+import app.random as random
+from AtlasLusoris.Map_of_Classes.Scroll_of_Constants import SUBCLASSES as subclasses
+
 
 class Ranger(Progression):
 	def __init__(self, character):
@@ -24,9 +33,12 @@ class Ranger(Progression):
 		# --- Core Ranger Features ---
 		if level >= 1:
 			roll_health(character)
+			from AtlasMagia.Lodge_of_Spells import HuntersMark
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+			grant_spell(character, HuntersMark)
 
 			features.append(Feature("Favored Enemy", 1,
-				f"""You always have the <i>Hunter’s Mark</i> spell prepared. You can cast it {favored_enemy} times without a spell slot, regaining all uses on a Long Rest."""))
+				f"""You always have {spell_mark(HuntersMark)} prepared. You can cast it {favored_enemy} times without a spell slot, regaining all uses on a Long Rest. See Spells."""))
 
 			features.append(Feature("Weapon Mastery", 1,
 				"""You can use the mastery properties of 2 weapons of your choice. You may change them after a Long Rest."""))

--- a/AtlasLusoris/Map_of_Classes/Training/Rogue.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Rogue.py
@@ -1,7 +1,7 @@
 from ..Grimoire_of_Health  import roll_health, HIT_DIE_TABLE
 from ..Codex_of_Progression import Progression
 
-from AtlasLusoris.Grimoire_of_Features import Feature
+from AtlasLusoris.Grimoire_of_Features import Feature, ApplyRandomFeats, ApplyEpicBoon
 
 class Rogue(Progression):
 	HIT_DIE = 8
@@ -42,9 +42,13 @@ class Rogue(Progression):
 				"""
 			))
 			# Thieves’ Cant
-			character.languages.Add({"Thieves' Cant"})
-			character.languages.AddAnyLanguage()
-			character.languages.AddAnyLanguage()
+			try:
+				from AtlasLudus.Map_of_Languages import all_languages
+				character.languages.Add("Thieves' Cant")
+				character.languages.AddAnyLanguage(all_languages)
+				character.languages.AddAnyLanguage(all_languages)
+			except Exception:
+				pass
 			feats.append(Feature(
 				"Weapon Mastery", 1,
 				"""

--- a/AtlasLusoris/Map_of_Classes/Training/Rogue.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Rogue.py
@@ -74,6 +74,8 @@ class Rogue(Progression):
 					]
 			if character.subclass == "Arcane Trickster":
 				from AtlasMagia.Lodge_of_Spells import MageHand
+				from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+				grant_spell(character, MageHand)
 				feats.append(Feature(
 					"Arcane Trickster", 3,
 					f"""
@@ -84,17 +86,17 @@ class Rogue(Progression):
 					"""
 					))
 				feats.append(Feature(
-					"Mage Hand Legerdemain", 3,
+					"Mage Hand Legerdemain",
 					f"""
-					You know the <i>Mage Hand</i> cantrip. <br>
+					You know {spell_mark(MageHand)}. <br>
 					When you cast Mage Hand, you can cast it as a
 					<i>Bonus Action</i>,
 					 and you can make the spectral hand Invisible.
 					 You can control the hand as a Bonus Action,
 					 and through it, you can make
-					 <i>Dexterity (Sleight of Hand)</i> checks.
-					 <div class="npc-textbox">{MageHand}</div>
-					"""
+					 <i>Dexterity (Sleight of Hand)</i> checks. See Spells.
+					""",
+					level=3,
 					))
 
 			if character.subclass == "Assassin":

--- a/AtlasLusoris/Map_of_Classes/Training/Warlock.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Warlock.py
@@ -5,7 +5,8 @@ from AtlasLusoris.Grimoire_of_Features import (
 	Feature,
 	BuildAvailableInvocations,
 	ApplyRandomFeats,
-	ApplyEpicBoon
+	ApplyEpicBoon,
+	owned_feature_names,
 	)
 import random
 
@@ -32,8 +33,12 @@ class Warlock(Progression):
 
 	def prepare_invocations(self):
 		n = Warlock.warlock_invocations_known(self.character.level)
-		available = list(BuildAvailableInvocations(self.character))
-		chosen = random.sample(available, min(n, len(available)))
+		owned = owned_feature_names(self.character)
+		available = [
+			inv for inv in BuildAvailableInvocations(self.character)
+			if getattr(inv, "name", "") not in owned
+			]
+		chosen = random.sample(available, min(n, len(available))) if available else []
 
 		self.character.invocations = []
 
@@ -41,6 +46,7 @@ class Warlock(Progression):
 		for inv in chosen:
 			inv(self.character)  # applies effect if needed
 			self.character.invocations.append(inv)
+			owned.add(getattr(inv, "name", ""))
 
 	def features(self, character):
 		features = []

--- a/AtlasLusoris/Map_of_Classes/Training/Warlock.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Warlock.py
@@ -217,10 +217,8 @@ class Warlock(Progression):
 					""",
 					"Class: Warlock"))
 			if subclass == "Genie":
-				random.seed(character.seed)
-				patron = random.choice([
-					"Dao", "Djinni", "Efreeti", "Marid"
-					])
+				from AtlasLusoris.Grimoire_of_Spellcasters import genie_kind
+				patron = genie_kind(character)
 
 				features.append(Feature("Genie Patron",
 					f"""You have made a pact with one of the rarest kinds of genie, a noble {patron} genie. Such entities rule vast fiefs on the Elemental Planes and have great influence over lesser genies and elemental creatures. Noble genies are varied in their motivations, but most are arrogant and wield power that rivals that of lesser deities. They delight in turning the table on mortals, who often bind genies into servitude, and readily enter into pacts that expand their reach.
@@ -530,12 +528,13 @@ As a bonus action, you can give yourself a flying speed of 30 feet that lasts fo
 
 		if level >= 9:
 			from AtlasMagia.Lodge_of_Spells import ContactOtherPlane
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+			grant_spell(character, ContactOtherPlane)
 			features.append(Feature("Contact Patron",
 				f"""
-In the past, you usually contacted your patron through intermediaries. Now you can communicate directly; you always have the Contact Other Plane spell prepared. With this feature, you can cast the spell without expending a spell slot to contact your patron, and you automatically succeed on the spell's saving throw.
+In the past, you usually contacted your patron through intermediaries. Now you can communicate directly; you always have {spell_mark(ContactOtherPlane)} prepared. With this feature, you can cast the spell without expending a spell slot to contact your patron, and you automatically succeed on the spell's saving throw.
 <br>
-Once you cast the spell with this feature, you can't do so in this way again until you finish a Long Rest.
-<div class="npc-textbox">{ContactOtherPlane}</div>
+Once you cast the spell with this feature, you can't do so in this way again until you finish a Long Rest. See Spells.
 				""",
 				"Class: Warlock"))
 		if level >= 10:
@@ -559,13 +558,14 @@ plus your Charisma modifier.
 					"Class: Warlock"))
 			if subclass == "Great Old One":
 				from AtlasMagia.Lodge_of_Spells import Hex
+				from AtlasLusoris.Compass_of_Learned_Spells import grant_spell, spell_mark
+				grant_spell(character, Hex)
 				features.append(Feature("Eldritch Hex",
 					f"""
 Your alien patron {patron} grants you a powerful curse.
-You always have the Hex spell prepared. When you cast Hex
+You always have {spell_mark(Hex)} prepared. When you cast Hex
 and choose an ability, the target also has Disadvantage on
-saving throws of the chosen ability for the duration of the spell.
-<div class="npc-textbox">{Hex}</div>
+saving throws of the chosen ability for the duration of the spell. See Spells.
 
 """,
 					"Class: Warlock"))

--- a/AtlasLusoris/Map_of_Classes/Training/Wizard.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Wizard.py
@@ -1,108 +1,672 @@
-from ..Grimoire_of_Health  import roll_health, HIT_DIE_TABLE
+from ..Grimoire_of_Health import roll_health
 from ..Codex_of_Progression import Progression
 
-from AtlasLusoris.Grimoire_of_Features import Feature, ApplyRandomFeats
+from AtlasLusoris.Grimoire_of_Features import (
+	Feature,
+	ApplyRandomFeats,
+	ApplyEpicBoon,
+	)
+from AtlasActorLudi.Map_of_Scores import Modifier
+
+import app.random as random
+
+
+# Each wizard tradition is a hunt for True Names of a different kind.
+# To know the name is to understand the thing, and to understand it
+# is to stand in relation to it — a door, never the whole of the Way.
+
+TRADITION_ALIASES = {
+	"Evoker": "Evoker",
+	"Evocation": "Evoker",
+	"Illusionist": "Illusionist",
+	"Illusion": "Illusionist",
+	"Necromancer": "Necromancer",
+	"Necromancy": "Necromancer",
+	"Diviner": "Diviner",
+	"Divination": "Diviner",
+	"Abjurer": "Abjurer",
+	"Abjuration": "Abjurer",
+	}
+
+TRADITIONS = {
+	"Evoker": {
+		"title": "Namer of Storms",
+		"school": "Evocation",
+		"sought_names": [
+			"Fire", "Lightning", "Thunder", "the Wind", "the Sun",
+			"Wildfire", "the First Spark", "the Forge-Heart",
+			"the Breaking Wave", "the Shout that Splits Stone",
+			"the Summer Heat", "the Unmaking Flame", "the Open Sky",
+			],
+		},
+	"Illusionist": {
+		"title": "Namer of Seeming",
+		"school": "Illusion",
+		"sought_names": [
+			"Shadow", "Mirror", "Fog", "Dream", "the Face", "Memory",
+			"the Veil", "Moonlight-on-Water", "the Echo", "the False Dawn",
+			"the Mask", "the Name that Is Not",
+			],
+		},
+	"Necromancer": {
+		"title": "Namer of Silence",
+		"school": "Necromancy",
+		"sought_names": [
+			"Dust", "the Last Breath", "Bone", "the Grave", "the Quiet",
+			"the Hollow Name", "the River of Ending", "Ash",
+			"the Unspoken Farewell", "the Cold that Remains",
+			"the Name that Outlives the Body",
+			],
+		},
+	"Diviner": {
+		"title": "Namer of the Unseen",
+		"school": "Divination",
+		"sought_names": [
+			"Fate", "Tomorrow", "the Hidden Thread", "the Unspoken",
+			"the Pattern", "the Forking Path", "the Eye Behind Sleep",
+			"the Name Before It Is Spoken", "the Still Water that Shows",
+			"the Ten Thousand Things",
+			],
+		},
+	"Abjurer": {
+		"title": "Namer of Binding",
+		"school": "Abjuration",
+		"sought_names": [
+			"Threshold", "the Closed Door", "the Uncarved Block",
+			"the Circle", "Iron", "the Ward", "the Name that Holds",
+			"the Center", "the Unbroken Line", "the Gate",
+			"the Name of No",
+			],
+		},
+	}
+
+# Spells whose True Names sit inside each tradition (by spell level).
+# Used to actually write savant names into the generated spellbook.
+SAVANT_NAMES = {
+	"Evoker": {
+		1: ["Magic Missile", "Thunderwave", "Burning Hands", "Chromatic Orb", "Witch Bolt"],
+		2: ["Scorching Ray", "Shatter", "Gust of Wind", "Flaming Sphere"],
+		3: ["Fireball", "Lightning Bolt", "Tiny Hut"],
+		4: ["Ice Storm", "Wall of Fire", "Fire Shield", "Vitriolic Sphere"],
+		5: ["Cone of Cold", "Bigby's Hand", "Wall of Force"],
+		6: ["Chain Lightning", "Sunbeam", "Otiluke's Freezing Sphere"],
+		7: ["Delayed Blast Fireball", "Crown of Stars", "Whirlwind"],
+		8: ["Incendiary Cloud", "Sunburst"],
+		9: ["Meteor Swarm"],
+		},
+	"Illusionist": {
+		1: ["Silent Image", "Disguise Self", "Color Spray", "Illusory Script"],
+		2: ["Invisibility", "Mirror Image", "Phantasmal Force", "Blur", "Magic Mouth"],
+		3: ["Major Image", "Hypnotic Pattern", "Fear", "Phantom Steed"],
+		4: ["Greater Invisibility", "Phantasmal Killer", "Hallucinatory Terrain"],
+		5: ["Mislead", "Seeming", "Dream"],
+		6: ["Programmed Illusion", "Mental Prison"],
+		7: ["Simulacrum", "Project Image", "Mirage Arcane"],
+		8: ["Illusory Dragon"],
+		9: ["Weird"],
+		},
+	"Necromancer": {
+		1: ["False Life", "Ray of Sickness", "Cause Fear"],
+		2: ["Blindness/Deafness", "Gentle Repose", "Ray of Enfeeblement"],
+		3: ["Animate Dead", "Vampiric Touch", "Bestow Curse", "Speak with Dead", "Feign Death", "Summon Undead"],
+		4: ["Blight", "Shadow of Moil"],
+		5: ["Danse Macabre", "Enervation", "Negative Energy Flood"],
+		6: ["Circle of Death", "Create Undead", "Eyebite", "Magic Jar"],
+		7: ["Finger of Death"],
+		8: ["Clone", "Abi-Dalzim's Horrid Wilting"],
+		9: ["Power Word Kill", "Astral Projection"],
+		},
+	"Diviner": {
+		1: ["Detect Magic", "Identify", "Comprehend Languages"],
+		2: ["Detect Thoughts", "See Invisibility", "Augury", "Locate Object", "Mind Spike"],
+		3: ["Clairvoyance", "Tongues", "Nondetection"],
+		4: ["Arcane Eye", "Divination", "Locate Creature"],
+		5: ["Scrying", "Legend Lore", "Rary's Telepathic Bond", "Contact Other Plane"],
+		6: ["True Seeing"],
+		7: ["Etherealness"],
+		8: ["Telepathy"],
+		9: ["Foresight"],
+		},
+	"Abjurer": {
+		1: ["Mage Armor", "Shield", "Protection from Evil and Good", "Alarm"],
+		2: ["Arcane Lock", "Mind Spike"],
+		3: ["Counterspell", "Dispel Magic", "Magic Circle", "Protection from Energy", "Remove Curse", "Glyph of Warding", "Nondetection"],
+		4: ["Banishment", "Stoneskin", "Private Sanctum"],
+		5: ["Circle of Power", "Wall of Force"],
+		6: ["Globe of Invulnerability", "Guards and Wards"],
+		7: ["Symbol", "Forcecage"],
+		8: ["Antimagic Field", "Mind Blank"],
+		9: ["Imprisonment", "Prismatic Wall"],
+		},
+	}
+
+SCHOLAR_SKILLS = [
+	"Arcana", "History", "Investigation", "Medicine", "Nature", "Religion",
+	]
+
+
+def resolve_tradition(subclass):
+	if not subclass:
+		return "Evoker"
+	return TRADITION_ALIASES.get(str(subclass).strip(), "Evoker")
+
+
+def wizard_feature(name, text, level=1):
+	"""Player-facing class feature. Description must be the body text."""
+	return Feature(name, text.strip(), source="Class: Wizard", level=level)
+
+
+def intelligence_modifier(character):
+	score = getattr(character.AS, "INT", 10)
+	return Modifier(score)
+
+
+def wizard_spell_index():
+	"""Map stripped spell names to Lodge objects, without requiring the full caster tables."""
+	index = {}
+	try:
+		import AtlasMagia.Lodge_of_Spells as lodge
+		for value in vars(lodge).values():
+			name = getattr(value, "name", None)
+			if not name:
+				continue
+			index[str(name).strip()] = value
+	except Exception:
+		pass
+	try:
+		from AtlasLusoris.Grimoire_of_Spellcasters import SPELL_LISTS
+		for spells in SPELL_LISTS.get("Wizard", {}).values():
+			for spell in spells:
+				index[spell.name.strip()] = spell
+	except Exception:
+		pass
+	return index
+
+
+def add_spells_to_book(character, spells):
+	caster = getattr(character, "spellcaster", None)
+	if caster is None or getattr(caster, "spells_known", None) is None:
+		return []
+	known = {spell.name.strip() for spell in caster.spells_known}
+	added = []
+	for spell in spells:
+		if spell is None:
+			continue
+		try:
+			int(getattr(spell, "level", 0))
+		except (TypeError, ValueError):
+			continue
+		key = spell.name.strip()
+		if key not in known:
+			caster.spells_known.append(spell)
+			known.add(key)
+			added.append(key)
+	return added
+
+
+def pick_savant_spells(tradition, wizard_level):
+	"""Savant: two school names of level 1–2, plus one per later slot level."""
+	catalog = SAVANT_NAMES.get(tradition, {})
+	picks = []
+	starter = list(catalog.get(1, [])) + list(catalog.get(2, []))
+	random.shuffle(starter)
+	picks.extend(starter[:2])
+	slot_levels = []
+	if wizard_level >= 5:
+		slot_levels.append(3)
+	if wizard_level >= 7:
+		slot_levels.append(4)
+	if wizard_level >= 9:
+		slot_levels.append(5)
+	if wizard_level >= 11:
+		slot_levels.append(6)
+	if wizard_level >= 13:
+		slot_levels.append(7)
+	if wizard_level >= 15:
+		slot_levels.append(8)
+	if wizard_level >= 17:
+		slot_levels.append(9)
+	for slot_level in slot_levels:
+		options = [name for name in catalog.get(slot_level, []) if name not in picks]
+		if options:
+			picks.append(random.choice(options))
+	index = wizard_spell_index()
+	return [index[name] for name in picks if name in index], picks
+
+
+def find_spells(names):
+	index = wizard_spell_index()
+	found = []
+	for name in names:
+		spell = index.get(name)
+		if spell is not None:
+			found.append(spell)
+	return found
 
 
 class Wizard(Progression):
+	HIT_DIE = 6
+
 	def __init__(self, character):
 		self.char = character
-	HIT_DIE = 6
-	def features(self, character):
-		level = character.Level
-		subclass = character.Subclass or "Abjurer"
-		features = []
-		feats = []
-		if level >= 1:
-			features.append(Feature("Ritual Adept", 1,
-				"You can cast any spell as a Ritual if that spell has the Ritual tag and the spell is in your spellbook. You needn't have the spell prepared, but you must read from the book to cast a spell in this way."))
-			features.append(Feature("Spellbook",1, """Your wizardly apprenticeship culminated in the creation of a unique book: your spellbook. It is a Tiny object that weighs 3 pounds, contains 100 pages, and can be read only by you or someone casting <b>Identify</b>.
-			You determine the book's appearance and materials, such as a gilt-edged tome or a collection of vellum bound with twine.<br>
-			The book contains the level 1+ spells you know.	 It starts with six level 1 Wizard spells of your choice. For each Wizard level after 1, add two Wizard spells of your choice to your spellbook. Each of these spells must be of a level for which you have spell slots. The spells are the culmination of arcane research you do regularly."""))
-			features.append(Feature("Expanding and Replacing a Spellbook",1, """The spells you add to your spellbook as you gain levels reflect your ongoing magical research, but you might find other spells during your adventures that you can add to the book. You could discover a Wizard spell on a Spell Scroll, for example, and then copy it into your spellbook.<br>
-				<b>Copying a Spell into the Book.</b> When you find a level 1+ Wizard spell, you can copy it into your spellbook if it's of a level you can prepare and if you have time to copy it. For each level of the spell, the transcription takes 2 hours and costs 50 GP. Afterward you can prepare the spell like the other spells in your spellbook. <br>
-				<b>Copying the Book.</b> You can copy a spell from your spellbook into another book. This is like copying a new spell into your spellbook but faster, since you already know how to cast the spell. You need spend only 1 hour and 10 GP for each level of the copied spell.<br>
-				If you lose your spellbook, you can use the same procedure to transcribe the Wizard spells that you have prepared into a new spellbook. Filling out the remainder of the new book requires you to find new spells to do so. For this reason, many wizards keep a backup spellbook."""))
-			features.append(Feature("Arcane Recovery", 1, "You can regain some of your magical energy by studying your spellbook. When you finish a Short Rest, you can choose expended spell slots to recover. The spell slots can have a combined level equal to no more than half your Wizard level (round up), and none of the slots can be level 6 or higher. For example, if you're a level 4 Wizard, you can recover up to two levels' worth of spell slots, regaining either one level 2 spell slot or two level 1 spell slots. <br> Once you use this feature, you can't do so again until you finish a Long Rest."))
-		if level >= 2:
-			roll_health(self.char)
-			features.append(Feature("Scholar", 2, "While studying magic, you also specialized in another field of study. Choose one of the following skills in which you have proficiency: Arcana, History, Investigation, Medicine, Nature, or Religion. You have Expertise in the chosen skill."))
-			character.skills.activate_expertise(
-				2,
-				["Arcana", "History",	"Investigation",	"Medicine",
-				"Nature",	"Religion"]
-				)
-		if level >= 3:
-			if subclass == "Evoker":
-				features.append(Feature("Evoker", 2,
-					"Your studies focus on magic that creates powerful elemental effects such as bitter cold, searing flame, rolling thunder, crackling lightning, and burning acid. Some Evokers find employment in military forces, serving as artillery to blast armies from afar. Others use their power to protect others, while some seek their own gain."))
-				features.append(Feature("Evocation Savant", 2,
-					"Choose two Wizard spells from the Evocation school, each of which must be no higher than level 2, and add them to your spellbook for free.<br>In addition, whenever you gain access to a new level of spell slots in this class, you can add one Wizard spell from the Evocation school to your spellbook for free. The chosen spell must be of a level for which you have spell slots."))
-				features.append(Feature("Potent Cantrip", 2,
-					"""Your damaging cantrips affect even creatures that avoid the brunt of the effect.
-					When you cast a cantrip at a creature and you miss with the attack roll or the target succeeds on a saving throw against the cantrip,
-					the target takes half the cantrip's damage (if any) but suffers no additional effect from the cantrip."""))
-		if level >= 4:
-			feats += ApplyRandomFeats(character, n=1)
-		if level >= 5:
-			features.append(Feature("Memorize Spell", 5,
-				"""Whenever you finish a Short Rest,
-				you can study your spellbook and replace one of the level
-				1+ Wizard spells you have prepared for your Spellcasting
-				feature with another level 1+ spell from the book."""))
 
-		if level >= 6 and subclass == "Evoker":
-			features.append(Feature("Sculpt Spells", 6,
-			"""You can create pockets of relative safety within the effects of
-			your evocations. When you cast an Evocation spell that affects
-			other creatures that you can see, you can choose a number of
-			them equal to 1 plus the spell's level. The chosen creatures
-			automatically succeed on their saving throws against the spell,
-			and they take no damage if they would normally take half damage
-			on a successful save."""))
+	def features(self, character=None):
+		if character is None:
+			character = self.char
+		else:
+			self.char = character
+
+		if hasattr(character, "set"):
+			character.set()
+
+		level = character.Level
+		tradition = resolve_tradition(character.Subclass)
+		lore = TRADITIONS[tradition]
+		sought_name = random.choice(lore["sought_names"])
+		int_bonus = intelligence_modifier(character)
+		features = []
+
+		if level >= 1:
+			features.extend(self._level_one(level, tradition, lore, sought_name))
+		if level >= 2:
+			roll_health(character)
+			features.append(self._scholar(character))
+		if level >= 3:
+			features.extend(self._tradition_features(
+				character, tradition, lore, sought_name, level, int_bonus))
+		if level >= 4:
+			features.extend(ApplyRandomFeats(character, n=1))
+		if level >= 5:
+			features.append(wizard_feature("Memorize Spell", f"""
+				After a Short Rest you may open the book and trade one prepared
+				Wizard spell of level 1 or higher for another name already written there.
+				The new spell must be of a level you can prepare.
+				<br><i>A name held in the mouth can be set down. Another can be taken up.
+				The book remembers what you do not.</i>
+				""", 5))
+		if level >= 6:
+			features.extend(self._tradition_level_six(
+				character, tradition, lore, sought_name, level, int_bonus))
 		if level >= 8:
-			feats += ApplyRandomFeats(character, n=1)
-		if level >= 10 and subclass == "Evoker":
-			features.append(Feature("Empowered Evocation", 10,
-			"Whenever you cast a Wizard spell from the Evocation school, you can add your Intelligence modifier to one damage roll of that spell."))
+			features.extend(ApplyRandomFeats(character, n=1))
+		if level >= 10:
+			features.extend(self._tradition_level_ten(
+				character, tradition, lore, sought_name, level, int_bonus))
 		if level >= 12:
-			feats += ApplyRandomFeats(character, n=1)
-		if level >= 14 and subclass == "Evoker":
-			features.append(Feature("Empowered Evocation", 10,
-			"""You can increase the power of your spells.
-			When you cast a Wizard spell with a spell slot of levels 1–5
-			that deals damage, you can deal maximum damage with that spell
-			on the turn you cast it. <br>
-			The first time you do so, you suffer no adverse effect.
-			If you use this feature again before you finish a Long Rest,
-			you take <b>2d12 Necrotic damage</b> for each level of the
-			spell slot immediately after you cast it. This damage ignores
-			Resistance and Immunity. <br>
-			Each time you use this feature again before finishing a
-			Long Rest, the Necrotic damage per spell level increases by
-			<b>1d12</b>."""))
+			features.extend(ApplyRandomFeats(character, n=1))
+		if level >= 14:
+			features.extend(self._tradition_level_fourteen(
+				character, tradition, lore, sought_name, level, int_bonus))
 		if level >= 16:
-			feats += ApplyRandomFeats(character, n=1)
+			features.extend(ApplyRandomFeats(character, n=1))
 		if level >= 18:
-			features.append(Feature("Spell Mastery", 18,
-			"""You have achieved such mastery over certain spells that you
-			can cast them at will. Choose a level 1 and a level 2 spell
-			in your spellbook that have a casting time of an action.
-			You always have those spells prepared, and you can cast them
-			at their lowest level without expending a spell slot. To cast
-			either spell at a higher level, you must expend a spell slot. <br>
-			Whenever you finish a Long Rest, you can study your spellbook and
-			replace one of those spells with an eligible spell of the same
-			level from the book."""))
+			features.append(wizard_feature("Spell Mastery", """
+				Choose one level 1 spell and one level 2 spell in your book
+				that have a casting time of an action. Those names live on your
+				tongue: you always have them prepared, and you can speak each
+				at its lowest level without a spell slot. A higher level still
+				costs a slot.
+				<br>When you finish a Long Rest, you may trade one of those
+				mastered names for another eligible spell of the same level
+				from the book.
+				<br><i>Some names, spoken often enough, stop being study
+				and become breath.</i>
+				""", 18))
 		if level >= 19:
-			feats += ApplyEpicBoon(character, n=1)
+			features.extend(ApplyEpicBoon(character, n=1))
 		if level >= 20:
-			features.append(Feature("Signature Spells", 20,
-			"""Choose two level 3 spells in your spellbook as your signature
-			spells. You always have these spells prepared, and you can cast
-			each of them once at level 3 without expending a spell slot.
-			When you do so, you can't cast them in this way again until you
-			finish a Short or Long Rest. To cast either spell at a higher
-			level, you must expend a spell slot."""))
-		features.extend(feats)
+			features.append(wizard_feature("Signature Spells", """
+				Choose two level 3 spells in your book as signature names.
+				You always have them prepared. You can cast each once at
+				level 3 without a spell slot, and you regain that use when
+				you finish a Short or Long Rest. A higher level still costs
+				a slot.
+				<br><i>These are the names that have learned you back.</i>
+				""", 20))
 		return features
+
+	def _level_one(self, level, tradition, lore, sought_name):
+		recovery = (level + 1) // 2
+		return [
+			wizard_feature("The Way of Names", f"""
+				To know a thing's True Name is to understand it, and to
+				understand it is to be able to connect with it. Wizards are
+				not born with power; they hunt names. They write them, taste
+				them, and speak them only when the world will answer.
+				<br>The named is never the whole of the Way — the name that
+				can be written is not the eternal name. Still, a true name
+				is a door.
+				<br>You are a <b>{tradition}</b>, a <i>{lore['title']}</i>.
+				The name you hunt is <b>{sought_name}</b>.
+				""", 1),
+			wizard_feature("Ritual Adept", """
+				If a spell in your book has the Ritual tag, you can speak it
+				as a Ritual even when it is not prepared. You must read from
+				the book. Some names will not be rushed; they want the long
+				voice, the unhurried breath.
+				""", 1),
+			wizard_feature("Spellbook", """
+				Your apprenticeship ended when you bound a book that only you
+				can read — unless someone casts <b>Identify</b> upon it.
+				It is a Tiny object, three pounds, a hundred pages. You choose
+				its skin: gilt-edge, twine and vellum, bone, or river-stone.
+				<br>It begins with six level 1 Wizard spells. Each Wizard level
+				after 1, you add two Wizard spells of a level you can slot.
+				These are names you research, dream, or wrestle into ink.
+				""", 1),
+			wizard_feature("Expanding the Book", """
+				Adventure yields names other wizards have already caught.
+				<b>Copying a new name.</b> When you find a level 1+ Wizard
+				spell you can prepare, you may transcribe it. Each level of
+				the spell takes 2 hours and 50 GP — ink, rare salts, the
+				quiet of copying a name without waking it wrong. Afterward
+				you can prepare it like any other name in the book.
+				<br><b>Copying your own book.</b> A name you already know
+				copies faster: 1 hour and 10 GP per spell level.
+				If the book is lost, you may write your currently prepared
+				spells into a new one this way. The rest of the book must
+				be found again. Wise namers keep a spare.
+				""", 1),
+			wizard_feature("Arcane Recovery", f"""
+				When you finish a Short Rest, you may study the book and
+				recover expended spell slots whose combined level is no more
+				than <b>{recovery}</b> (half your Wizard level, rounded up).
+				None of those slots can be level 6 or higher. Once you do
+				this, you cannot do so again until you finish a Long Rest.
+				<br><i>The names recede when they are spent. Reading them
+				again is how you call them home.</i>
+				""", 1),
+			]
+
+	def _scholar(self, character):
+		skill = random.choice(SCHOLAR_SKILLS)
+		try:
+			character.skills.activate_expertise(1, [skill])
+		except Exception:
+			pass
+		return wizard_feature("Scholar", f"""
+			While hunting names you also specialized in another field of
+			study. You have Expertise in <b>{skill}</b>.
+			<br><i>A true name sits in a web of lesser names. Scholarship
+			is learning which threads to pull.</i>
+			""", 2)
+
+	def _tradition_features(self, character, tradition, lore, sought_name, level, int_bonus):
+		school = lore["school"]
+		added_spells, pick_names = pick_savant_spells(tradition, level)
+		written = add_spells_to_book(character, added_spells)
+		written_line = ", ".join(written or pick_names[:2]) or f"two {school} spells"
+		savant = wizard_feature(f"{school} Savant", f"""
+			The True Names of {school.lower()} come cheaper to your hand.
+			You add the following names to your book without the usual
+			time or gold: <b>{written_line}</b>.
+			<br>Whenever you gain a new level of spell slots in this class,
+			you may add one Wizard spell of the {school} school to the book
+			for free, of a level you can slot.
+			""", 3)
+		if tradition == "Evoker":
+			return [
+				wizard_feature("Namer of Storms", f"""
+					You hunt the True Names of what moves: flame, thunder,
+					the bright edge of force. Yang. To name the storm is
+					not to own it — it is to stand inside it and remain
+					yourself. The name you hunt is <b>{sought_name}</b>.
+					""", 3),
+				savant,
+				wizard_feature("Potent Cantrip", """
+					Even a glancing name leaves a mark. When you cast a
+					damaging cantrip and miss, or the target succeeds on
+					its save, the target still takes half the cantrip's
+					damage (if any) and suffers no other effect.
+					""", 3),
+				]
+		if tradition == "Illusionist":
+			add_spells_to_book(character, find_spells(["Minor Illusion"]))
+			return [
+				wizard_feature("Namer of Seeming", f"""
+					The named is not the thing. You hunt names of shadow,
+					mirror, and mask — not to lie, but to show how thin
+					the veil is between is and seems. Do not force the eye;
+					name what it is already willing to believe.
+					The name you hunt is <b>{sought_name}</b>.
+					""", 3),
+				savant,
+				wizard_feature("Improved Illusions", """
+					You always know <i>Minor Illusion</i>, and you can cast
+					it as a Bonus Action. When you do, the illusion may
+					include both a sound and an image. You can see through
+					your own illusions, and Illusion spells you cast no
+					longer require Verbal components.
+					<br><i>A name of seeming should not need to be shouted.</i>
+					""", 3),
+				]
+		if tradition == "Necromancer":
+			return [
+				wizard_feature("Namer of Silence", f"""
+					Yin. Return. The valley spirit that does not die.
+					You hunt last names: dust, the breath leaving, the
+					hollow that remains. To name death is not to worship
+					it. It is to know where the river goes, and to speak
+					with what the river keeps. The name you hunt is
+					<b>{sought_name}</b>.
+					""", 3),
+				savant,
+				wizard_feature("Grim Harvest", """
+					Once per turn, when you kill a creature that is not a
+					Construct or Undead with a spell of level 1 or higher,
+					you regain Hit Points equal to twice the spell's level,
+					or three times the level if the spell is Necromancy.
+					<br><i>A little of the last name returns to you as breath.</i>
+					""", 3),
+				]
+		if tradition == "Diviner":
+			dice_count = 3 if level >= 14 else 2
+			portent = [random.randint(1, 20) for _ in range(dice_count)]
+			portent_text = " and ".join(f"<b>{roll}</b>" for roll in portent)
+			return [
+				wizard_feature("Namer of the Unseen", f"""
+					You hunt names that have not yet been spoken: fate,
+					the hidden thread, tomorrow. The ten thousand things
+					announce themselves before they arrive, if you know
+					how to listen. You do not command the future. You
+					recognize its name when it leans toward you.
+					The name you hunt is <b>{sought_name}</b>.
+					""", 3),
+				savant,
+				wizard_feature("Portent", f"""
+					When you finish a Long Rest, you roll {dice_count} d20s
+					and keep the numbers. You may replace any attack roll,
+					saving throw, or ability check made by you or a creature
+					you can see with one of those numbers. You choose before
+					the roll. Each number is spent when you use it, and any
+					unused numbers fade when you finish a Long Rest.
+					<br>Today the unseen leans toward: {portent_text}.
+					""", 3),
+				]
+		# Abjurer
+		ward_hp = 2 * level + int_bonus
+		return [
+			wizard_feature("Namer of Binding", f"""
+				The uncarved block. The closed door. You hunt names that
+				hold: threshold, circle, iron, the center that does not
+				move. Power is not only what you send out. It is what you
+				refuse, what you keep, what you name as not-yet-broken.
+				The name you hunt is <b>{sought_name}</b>.
+				""", 3),
+			savant,
+			wizard_feature("Arcane Ward", f"""
+				When you cast an Abjuration spell with a spell slot, you
+				may write the Name of Binding around yourself. The ward
+				lasts until you finish a Long Rest. It has a Hit Point
+				maximum of <b>{ward_hp}</b> (twice your Wizard level plus
+				your Intelligence modifier).
+				<br>Whenever you take damage, the ward takes it first.
+				If the ward drops to 0 Hit Points, you take the rest.
+				While it has 0 Hit Points it cannot absorb, but the
+				writing remains. Each time you cast an Abjuration spell
+				with a slot, the ward regains Hit Points equal to twice
+				that slot's level. You can create the ward only once
+				per Long Rest.
+				""", 3),
+			]
+
+	def _tradition_level_six(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Evoker":
+			return [wizard_feature("Sculpt Spells", f"""
+				When you cast an Evocation spell that other creatures you
+				can see would suffer, you may name a number of them equal
+				to 1 plus the spell's level as <i>not-this-fire</i>. Those
+				creatures automatically succeed on their saving throws
+				against the spell, and they take no damage if they would
+				normally take half on a success.
+				<br><i>The Name of {sought_name} does not strike what you
+				have named as kin.</i>
+				""", 6)]
+		if tradition == "Illusionist":
+			add_spells_to_book(character, find_spells(["Summon Beast", "Summon Fey"]))
+			return [wizard_feature("Phantasmal Creatures", """
+				You always have <i>Summon Beast</i> and <i>Summon Fey</i>
+				prepared. Once per Long Rest you can cast one of them
+				without a spell slot; the summoned creature is slightly
+				translucent — a true-seeming, not a true body. When you
+				cast either spell with a spell slot, it does not require
+				Concentration.
+				<br><i>A name of seeming, spoken carefully, will wear a shape
+				until the shape remembers it is fog.</i>
+				""", 6)]
+		if tradition == "Necromancer":
+			add_spells_to_book(character, find_spells(["Animate Dead"]))
+			thrall_hp = level
+			return [wizard_feature("Undead Thralls", f"""
+				You always have <i>Animate Dead</i> prepared. When you cast
+				it, you can target one additional corpse or pile of bones.
+				Undead you create with a Necromancy spell add your Wizard
+				level (<b>+{thrall_hp}</b> Hit Points) to their Hit Point
+				maximum, and they add your Proficiency Bonus to the damage
+				of their weapon attacks.
+				<br><i>A last name, spoken kindly or not, will stand up
+				if you know how to hold it.</i>
+				""", 6)]
+		if tradition == "Diviner":
+			return [wizard_feature("Expert Divination", """
+				When you cast a Divination spell using a spell slot of
+				level 2 or higher, you regain one expended spell slot.
+				The regained slot must be of a lower level than the one
+				you spent, and it cannot be level 6 or higher.
+				<br><i>To see a name before it arrives is to spend less
+				breath when it does.</i>
+				""", 6)]
+		return [wizard_feature("Projected Ward", """
+			When a creature you can see within 30 feet takes damage, you
+			can take a Reaction to let your Arcane Ward drink that damage
+			instead. If the ward drops to 0 Hit Points, the creature takes
+			the rest.
+			<br><i>The Name of Binding can be spoken over someone else.
+			The center holds, even at a step's distance.</i>
+			""", 6)]
+
+	def _tradition_level_ten(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Evoker":
+			bonus = max(1, int_bonus)
+			return [wizard_feature("Empowered Evocation", f"""
+				Whenever you cast a Wizard spell from the Evocation school,
+				you can add your Intelligence modifier (<b>+{bonus}</b>)
+				to one damage roll of that spell.
+				<br><i>You no longer borrow {sought_name}. It answers in
+				your own voice.</i>
+				""", 10)]
+		if tradition == "Illusionist":
+			return [wizard_feature("Illusory Self", """
+				When a creature hits you with an attack roll, you can take
+				a Reaction to interpose a duplicate of yourself. The attack
+				misses. Once you do this, you cannot do so again until you
+				finish a Short or Long Rest, unless you expend a spell slot
+				of level 2 or higher (no action) to restore the use.
+				<br><i>The name of you, and the you that is named, are not
+				always in the same place.</i>
+				""", 10)]
+		if tradition == "Necromancer":
+			return [wizard_feature("Inured to Undeath", """
+				You have Resistance to Necrotic damage, and your Hit Point
+				maximum cannot be reduced.
+				<br><i>You have heard the Name of Silence so often it no
+				longer startles your body.</i>
+				""", 10)]
+		if tradition == "Diviner":
+			uses = max(1, int_bonus)
+			return [wizard_feature("The Third Eye", f"""
+				As a Bonus Action you may open a third way of seeing, lasting
+				10 minutes. Choose one:
+				<ul>
+				<li><b>Darkvision</b> out to 120 feet.</li>
+				<li><b>Greater Comprehension.</b> You can read any language.</li>
+				<li><b>See Invisibility.</b> You see Invisible creatures and
+				objects, and you can see into the Ethereal Plane, out to
+				10 feet.</li>
+				</ul>
+				You can do this <b>{uses}</b> times (your Intelligence
+				modifier, minimum once), and you regain all uses when you
+				finish a Long Rest.
+				""", 10)]
+		add_spells_to_book(character, find_spells(["Counterspell", "Dispel Magic"]))
+		return [wizard_feature("Spell Breaker", """
+			You always have <i>Counterspell</i> and <i>Dispel Magic</i>
+			prepared. You can cast Dispel Magic as a Bonus Action, and you
+			add your Proficiency Bonus to its ability check.
+			When you cast either spell this way, your Arcane Ward regains
+			Hit Points equal to the spell's level.
+			<br><i>To unname a working is also a name. The ward drinks
+			what you take apart.</i>
+			""", 10)]
+
+	def _tradition_level_fourteen(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Evoker":
+			return [wizard_feature("Overchannel", f"""
+				When you cast a Wizard spell with a spell slot of levels
+				1–5 that deals damage, you can deal maximum damage with
+				that spell on the turn you cast it.
+				<br>The first time you do so, you suffer no adverse effect.
+				If you use this feature again before you finish a Long Rest,
+				you take <b>2d12 Necrotic damage</b> per level of the spell
+				slot immediately after you cast it. This damage ignores
+				Resistance and Immunity. Each further use before a Long Rest
+				increases that Necrotic damage by <b>1d12</b> per spell level.
+				<br><i>Speak a name too completely and the unnamed Way takes
+				its due. {sought_name} is not a tool. It is a relationship,
+				and relationships burn.</i>
+				""", 14)]
+		if tradition == "Illusionist":
+			return [wizard_feature("Illusory Reality", """
+				When you cast an Illusion spell with a spell slot, you can
+				choose one inanimate, nonmagical object that is part of the
+				illusion and make that object real for 1 minute. The object
+				cannot deal damage or otherwise directly harm anyone.
+				<br><i>Seeming, held long enough in a true name, forgets
+				that it was only seeming. For a minute, the world agrees.</i>
+				""", 14)]
+		if tradition == "Necromancer":
+			return [wizard_feature("Command Undead", """
+				As an Action, choose one Undead you can see within 60 feet.
+				It must succeed on a Charisma saving throw against your
+				spell save DC or obey your commands until you use this
+				feature again. Intelligent Undead (Intelligence 8 or higher)
+				have Advantage, and if they succeed they are immune to
+				your Command Undead for 24 hours. If it is already under
+				another creature's control, you steal that control on a
+				failure.
+				<br><i>A last name, once learned, can be spoken by more
+				than one throat. You make sure it is yours.</i>
+				""", 14)]
+		if tradition == "Diviner":
+			return [wizard_feature("Greater Portent", """
+				The unseen now offers three numbers instead of two when
+				you finish a Long Rest.
+				<br><i>The Pattern is not a chain. It is a braid, and you
+				have learned to hold a third strand.</i>
+				""", 14)]
+		return [wizard_feature("Spell Resistance", """
+			You have Advantage on saving throws against spells, and you
+			have Resistance to the damage of spells.
+			<br><i>Other people's names slide off the uncarved block.
+			You are harder to rewrite.</i>
+			""", 14)]

--- a/AtlasLusoris/Map_of_Classes/Training/Wizard.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Wizard.py
@@ -176,6 +176,28 @@ BLADESINGER_SKILLS = [
 	]
 
 
+def skill_training_level(character, name):
+	skills = getattr(character, "skills", None)
+	if skills is None:
+		return 0
+	attr = str(name).replace(" ", "_")
+	skill = getattr(skills, attr, None)
+	try:
+		return int(getattr(skill, "proficiency_level", 0) or 0)
+	except (TypeError, ValueError):
+		return 0
+
+
+def pick_unlearned_skill(character, options, need_level=1):
+	"""Pick a skill the character does not already have at this training level."""
+	fresh = [
+		name for name in options
+		if skill_training_level(character, name) < need_level
+		]
+	pool = fresh or list(options)
+	return random.choice(pool) if pool else None
+
+
 def resolve_tradition(subclass):
 	if not subclass:
 		return "Evoker"
@@ -234,10 +256,12 @@ def wizard_spell_index():
 
 
 def add_spells_to_book(character, spells):
+	"""Write extra names into the granted catalog. Does not spend class-known slots."""
+	from AtlasLusoris.Compass_of_Learned_Spells import catalog_keys, know_spell, spell_key
 	caster = getattr(character, "spellcaster", None)
-	if caster is None or getattr(caster, "spells_known", None) is None:
+	if caster is None:
 		return []
-	known = {spell.name.strip() for spell in caster.spells_known}
+	have = catalog_keys(caster)
 	added = []
 	for spell in spells:
 		if spell is None:
@@ -246,24 +270,29 @@ def add_spells_to_book(character, spells):
 			int(getattr(spell, "level", 0))
 		except (TypeError, ValueError):
 			continue
-		key = spell.name.strip()
-		if key not in known:
-			caster.spells_known.append(spell)
-			known.add(key)
-			added.append(key)
+		key = spell_key(spell)
+		if not key or key in have:
+			continue
+		know_spell(character, spell, always_prepared=False)
+		have.add(key)
+		added.append(key)
 	return added
 
 
 def pick_savant_spells(tradition, wizard_level, character=None):
 	"""Savant: two school names of level 1–2, plus one per later slot level. Grows; does not reshuffle."""
-	from AtlasLusoris.Compass_of_Learned_Spells import caster_rng
+	from AtlasLusoris.Compass_of_Learned_Spells import catalog_keys, caster_rng
 	catalog = SAVANT_NAMES.get(tradition, {})
 	traditions = list(TRADITIONS.keys())
 	salt = 0x5A1 ^ (traditions.index(tradition) if tradition in traditions else 0)
 	rng = caster_rng(character, salt) if character is not None else random
+	owned = catalog_keys(getattr(character, "spellcaster", None)) if character is not None else set()
 	picks = []
 	if wizard_level >= 3:
-		starter = list(catalog.get(1, [])) + list(catalog.get(2, []))
+		starter = [
+			name for name in list(catalog.get(1, [])) + list(catalog.get(2, []))
+			if name not in owned
+			]
 		rng.shuffle(starter)
 		picks.extend(starter[:2])
 	slot_unlocks = [
@@ -272,7 +301,10 @@ def pick_savant_spells(tradition, wizard_level, character=None):
 	for req_level, slot_level in slot_unlocks:
 		if wizard_level < req_level:
 			continue
-		options = [name for name in catalog.get(slot_level, []) if name not in picks]
+		options = [
+			name for name in catalog.get(slot_level, [])
+			if name not in picks and name not in owned
+			]
 		rng.shuffle(options)
 		if options:
 			picks.append(options[0])
@@ -423,9 +455,10 @@ class Wizard(Progression):
 			]
 
 	def _scholar(self, character):
-		skill = random.choice(SCHOLAR_SKILLS)
+		skill = pick_unlearned_skill(character, SCHOLAR_SKILLS, need_level=2)
 		try:
-			character.skills.activate_expertise(1, [skill])
+			if skill:
+				character.skills.activate_expertise(1, [skill])
 		except Exception:
 			pass
 		return wizard_feature("Scholar", f"""
@@ -436,13 +469,14 @@ class Wizard(Progression):
 
 	def _bladesinger_three(self, character, lore, sought_name, int_bonus):
 		song_uses = max(1, int_bonus)
-		skill = random.choice(BLADESINGER_SKILLS)
+		skill = pick_unlearned_skill(character, BLADESINGER_SKILLS, need_level=1)
 		try:
 			character.skills.Martial_Weapons.set_proficiency()
 		except Exception:
 			pass
 		try:
-			character.skills.activate_proficiencies(1, [skill])
+			if skill:
+				character.skills.activate_proficiencies(1, [skill])
 		except Exception:
 			try:
 				getattr(character.skills, skill).set_proficiency()

--- a/AtlasLusoris/Map_of_Classes/Training/Wizard.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Wizard.py
@@ -26,6 +26,8 @@ TRADITION_ALIASES = {
 	"Divination": "Diviner",
 	"Abjurer": "Abjurer",
 	"Abjuration": "Abjurer",
+	"Bladesinger": "Bladesinger",
+	"Bladesinging": "Bladesinger",
 	}
 
 TRADITIONS = {
@@ -72,10 +74,19 @@ TRADITIONS = {
 		"title": "Namer of Binding",
 		"school": "Abjuration",
 		"sought_names": [
-			"Threshold", "the Closed Door", "the Uncarved Block",
+			"Threshold", "the Closed Door",
 			"the Circle", "Iron", "the Ward", "the Name that Holds",
 			"the Center", "the Unbroken Line", "the Gate",
 			"the Name of No",
+			],
+		},
+	"Bladesinger": {
+		"title": "Namer of the Road",
+		"school": None,
+		"sought_names": [
+			"the Road", "the Step", "the Blade", "the Song",
+			"the Turning", "the Open Mile", "Wind-in-Grass",
+			"the Name You Learn by Walking",
 			],
 		},
 	}
@@ -144,11 +155,50 @@ SCHOLAR_SKILLS = [
 	"Arcana", "History", "Investigation", "Medicine", "Nature", "Religion",
 	]
 
+BOOK_BINDINGS = [
+	"a gilt-edged tome",
+	"vellum bound with twine",
+	"covers of pale bone",
+	"boards of river-stone",
+	]
+
+BOOK_MARKS = [
+	"A pressed leaf marks a page you have not copied yet.",
+	"The spine is worn from a pack, not a lectern.",
+	"A stranger's notes fill the margin, then stop mid-sentence.",
+	"Rain wrinkled the first gathering of pages.",
+	"A ribbon the color of old rust keeps your place.",
+	"You mended the clasp with wire from a camp kettle.",
+	]
+
+BLADESINGER_SKILLS = [
+	"Acrobatics", "Performance", "Athletics", "Stealth",
+	]
+
 
 def resolve_tradition(subclass):
 	if not subclass:
 		return "Evoker"
 	return TRADITION_ALIASES.get(str(subclass).strip(), "Evoker")
+
+
+def describe_wizard_book(character):
+	"""Pick one lived-in book. A seed, not a sentence the player must keep."""
+	existing = getattr(character, "wizard_book", None)
+	if existing:
+		return existing
+	from AtlasLusoris.Compass_of_Learned_Spells import caster_rng
+	rng = caster_rng(character, 0xB00) if character is not None else random
+	binding = rng.choice(BOOK_BINDINGS)
+	mark = rng.choice(BOOK_MARKS)
+	book = {
+		"binding": binding,
+		"mark": mark,
+		"line": f"{binding}. {mark}",
+		}
+	if character is not None:
+		character.wizard_book = book
+	return book
 
 
 def wizard_feature(name, text, level=1):
@@ -275,10 +325,8 @@ class Wizard(Progression):
 		if level >= 5:
 			features.append(wizard_feature("Memorize Spell", f"""
 				After a Short Rest you may open the book and trade one prepared
-				Wizard spell of level 1 or higher for another name already written there.
-				The new spell must be of a level you can prepare.
-				<br><i>A name held in the mouth can be set down. Another can be taken up.
-				The book remembers what you do not.</i>
+				Wizard spell of level 1 or higher for another spell already
+				written there. The new spell must be of a level you can prepare.
 				""", 5))
 		if level >= 6:
 			features.extend(self._tradition_level_six(
@@ -298,70 +346,72 @@ class Wizard(Progression):
 		if level >= 18:
 			features.append(wizard_feature("Spell Mastery", """
 				Choose one level 1 spell and one level 2 spell in your book
-				that have a casting time of an action. Those names live on your
-				tongue: you always have them prepared, and you can speak each
-				at its lowest level without a spell slot. A higher level still
-				costs a slot.
+				that have a casting time of an action. You always have them
+				prepared, and you can cast each at its lowest level without
+				a spell slot. A higher level still costs a slot.
 				<br>When you finish a Long Rest, you may trade one of those
-				mastered names for another eligible spell of the same level
+				mastered spells for another eligible spell of the same level
 				from the book.
-				<br><i>Some names, spoken often enough, stop being study
-				and become breath.</i>
 				""", 18))
 		if level >= 19:
 			features.extend(ApplyEpicBoon(character, n=1))
 		if level >= 20:
 			features.append(wizard_feature("Signature Spells", """
-				Choose two level 3 spells in your book as signature names.
+				Choose two level 3 spells in your book as signature spells.
 				You always have them prepared. You can cast each once at
 				level 3 without a spell slot, and you regain that use when
 				you finish a Short or Long Rest. A higher level still costs
 				a slot.
-				<br><i>These are the names that have learned you back.</i>
 				""", 20))
 		return features
 
 	def _level_one(self, level, tradition, lore, sought_name):
 		recovery = (level + 1) // 2
+		book = describe_wizard_book(self.char)
 		return [
 			wizard_feature("The Way of Names", f"""
-				To know a thing's True Name is to understand it, and to
-				understand it is to be able to connect with it. Wizards are
-				not born with power; they hunt names. They write them, taste
-				them, and speak them only when the world will answer.
-				<br>The named is never the whole of the Way — the name that
-				can be written is not the eternal name. Still, a true name
-				is a door.
-				<br>You are a <b>{tradition}</b>, a <i>{lore['title']}</i>.
+				Wizards are not born with power. They hunt names: they write
+				them, they walk toward them, they speak them only when the
+				world will answer.
+				<br>
+				But a map is irrelevant to someone who has never walked the
+				road. A map is not a country. So you went out there, a long
+				way from any library, walking towards the names you wanted
+				to learn. Wonder is what happens to you in the world. The
+				book is only how you carry the memory of it along.
+				<br>
+				You are a <b>{tradition}</b>, a <i>{lore['title']}</i>.
 				The name you hunt is <b>{sought_name}</b>.
+				If another name is calling, take that one instead — this is
+				only a first step.
 				""", 1),
 			wizard_feature("Ritual Adept", """
-				If a spell in your book has the Ritual tag, you can speak it
+				If a spell in your book has the Ritual tag, you can cast it
 				as a Ritual even when it is not prepared. You must read from
-				the book. Some names will not be rushed; they want the long
-				voice, the unhurried breath.
+				the book. Some names will not be rushed.
 				""", 1),
-			wizard_feature("Spellbook", """
+			wizard_feature("Spellbook", f"""
 				Your apprenticeship ended when you bound a book that only you
 				can read — unless someone casts <b>Identify</b> upon it.
-				It is a Tiny object, three pounds, a hundred pages. You choose
-				its skin: gilt-edge, twine and vellum, bone, or river-stone.
-				<br>It begins with six level 1 Wizard spells. Each Wizard level
+				It is a Tiny object, three pounds, a hundred pages.
+				<br>
+				This one is {book['line']}
+				You can change how it looks; this is only how it found you.
+				<br>
+				It begins with six level 1 Wizard spells. Each Wizard level
 				after 1, you add two Wizard spells of a level you can slot.
-				These are names you research, dream, or wrestle into ink.
 				""", 1),
 			wizard_feature("Expanding the Book", """
-				Adventure yields names other wizards have already caught.
-				<b>Copying a new name.</b> When you find a level 1+ Wizard
+				The rest of the book is still out there.
+				<br><b>Copying a new name.</b> When you find a level 1+ Wizard
 				spell you can prepare, you may transcribe it. Each level of
-				the spell takes 2 hours and 50 GP — ink, rare salts, the
-				quiet of copying a name without waking it wrong. Afterward
-				you can prepare it like any other name in the book.
+				the spell takes 2 hours and 50 GP. Afterward you can prepare
+				it like any other spell in the book.
 				<br><b>Copying your own book.</b> A name you already know
 				copies faster: 1 hour and 10 GP per spell level.
 				If the book is lost, you may write your currently prepared
-				spells into a new one this way. The rest of the book must
-				be found again. Wise namers keep a spare.
+				spells into a new one this way. The rest must be found again.
+				Wise wizards keep a spare.
 				""", 1),
 			wizard_feature("Arcane Recovery", f"""
 				When you finish a Short Rest, you may study the book and
@@ -369,8 +419,6 @@ class Wizard(Progression):
 				than <b>{recovery}</b> (half your Wizard level, rounded up).
 				None of those slots can be level 6 or higher. Once you do
 				this, you cannot do so again until you finish a Long Rest.
-				<br><i>The names recede when they are spent. Reading them
-				again is how you call them home.</i>
 				""", 1),
 			]
 
@@ -383,18 +431,66 @@ class Wizard(Progression):
 		return wizard_feature("Scholar", f"""
 			While hunting names you also specialized in another field of
 			study. You have Expertise in <b>{skill}</b>.
-			<br><i>A true name sits in a web of lesser names. Scholarship
-			is learning which threads to pull.</i>
+			You can change which field, if this one is not yours.
 			""", 2)
 
+	def _bladesinger_three(self, character, lore, sought_name, int_bonus):
+		song_uses = max(1, int_bonus)
+		skill = random.choice(BLADESINGER_SKILLS)
+		try:
+			character.skills.Martial_Weapons.set_proficiency()
+		except Exception:
+			pass
+		try:
+			character.skills.activate_proficiencies(1, [skill])
+		except Exception:
+			try:
+				getattr(character.skills, skill).set_proficiency()
+			except Exception:
+				pass
+		return [
+			wizard_feature("Bladesinger", f"""
+				You left the library. The names you wanted were not only on
+				the shelf; they were in the way a blade turns, in the length
+				of a step, in the song that keeps a body honest while it
+				thinks. You learn names with your feet as much as with the
+				page.
+				<br>
+				You are a <b>Bladesinger</b>, a <i>{lore['title']}</i>.
+				The name you hunt is <b>{sought_name}</b>.
+				""", 3),
+			wizard_feature("Training in War and Song", f"""
+				You have proficiency with Martial melee weapons that are
+				not two-handed or Heavy. You can use a melee weapon as a
+				Spellcasting Focus for your Wizard spells.
+				You also have proficiency in <b>{skill}</b>
+				(change it if another skill is more yours).
+				""", 3),
+			wizard_feature("Bladesong", f"""
+				If you are not wearing armor or a Shield, you can start
+				the Bladesong as a Bonus Action. It lasts 1 minute, and
+				ends early if you wear armor, use a two-handed weapon,
+				become Incapacitated, or choose to end it (no action).
+				<br>While it lasts: add your Intelligence modifier to AC;
+				gain +10 feet of speed; use Intelligence for melee weapon
+				attack and damage rolls; add your Intelligence modifier
+				to Constitution saving throws to maintain Concentration.
+				<br>You can use this <b>{song_uses}</b> times (Intelligence
+				modifier, minimum once). You regain one use when you use
+				Arcane Recovery, and all uses when you finish a Long Rest.
+				""", 3),
+			]
+
 	def _tradition_features(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Bladesinger":
+			return self._bladesinger_three(character, lore, sought_name, int_bonus)
 		school = lore["school"]
 		added_spells, pick_names = pick_savant_spells(tradition, level, character)
 		written = add_spells_to_book(character, added_spells)
 		written_line = ", ".join(written or pick_names[:2]) or f"two {school} spells"
 		savant = wizard_feature(f"{school} Savant", f"""
-			The True Names of {school.lower()} come cheaper to your hand.
-			You add the following names to your book without the usual
+			Spells of the {school} school come cheaper to your hand.
+			You add the following spells to your book without the usual
 			time or gold: <b>{written_line}</b>.
 			<br>Whenever you gain a new level of spell slots in this class,
 			you may add one Wizard spell of the {school} school to the book
@@ -403,17 +499,16 @@ class Wizard(Progression):
 		if tradition == "Evoker":
 			return [
 				wizard_feature("Namer of Storms", f"""
-					You hunt the True Names of what moves: flame, thunder,
-					the bright edge of force. Yang. To name the storm is
-					not to own it — it is to stand inside it and remain
-					yourself. The name you hunt is <b>{sought_name}</b>.
+					You hunt names of what moves: flame, thunder, the bright
+					edge of force. To name the storm is not to own it — it is
+					to stand inside it and remain yourself.
+					The name you hunt is <b>{sought_name}</b>.
 					""", 3),
 				savant,
 				wizard_feature("Potent Cantrip", """
-					Even a glancing name leaves a mark. When you cast a
-					damaging cantrip and miss, or the target succeeds on
-					its save, the target still takes half the cantrip's
-					damage (if any) and suffers no other effect.
+					When you cast a damaging cantrip and miss, or the target
+					succeeds on its save, the target still takes half the
+					cantrip's damage (if any) and suffers no other effect.
 					""", 3),
 				]
 		if tradition == "Illusionist":
@@ -423,10 +518,8 @@ class Wizard(Progression):
 				grant_spell(character, spell)
 			return [
 				wizard_feature("Namer of Seeming", f"""
-					The named is not the thing. You hunt names of shadow,
-					mirror, and mask — not to lie, but to show how thin
-					the veil is between is and seems. Do not force the eye;
-					name what it is already willing to believe.
+					You hunt names of shadow, mirror, and mask — not to lie,
+					but to show how thin the veil is between is and seems.
 					The name you hunt is <b>{sought_name}</b>.
 					""", 3),
 				savant,
@@ -435,19 +528,16 @@ class Wizard(Progression):
 					it as a Bonus Action. When you do, the illusion may
 					include both a sound and an image. You can see through
 					your own illusions, and Illusion spells you cast no
-					longer require Verbal components.
-					<br><i>A name of seeming should not need to be shouted.</i>
+					longer require Verbal components. See Spells.
 					""", 3),
 				]
 		if tradition == "Necromancer":
 			return [
 				wizard_feature("Namer of Silence", f"""
-					Yin. Return. The valley spirit that does not die.
 					You hunt last names: dust, the breath leaving, the
-					hollow that remains. To name death is not to worship
-					it. It is to know where the river goes, and to speak
-					with what the river keeps. The name you hunt is
-					<b>{sought_name}</b>.
+					hollow that remains. To name death is not to worship it.
+					It is to know where the river goes.
+					The name you hunt is <b>{sought_name}</b>.
 					""", 3),
 				savant,
 				wizard_feature("Grim Harvest", """
@@ -455,7 +545,6 @@ class Wizard(Progression):
 					Construct or Undead with a spell of level 1 or higher,
 					you regain Hit Points equal to twice the spell's level,
 					or three times the level if the spell is Necromancy.
-					<br><i>A little of the last name returns to you as breath.</i>
 					""", 3),
 				]
 		if tradition == "Diviner":
@@ -465,10 +554,8 @@ class Wizard(Progression):
 			return [
 				wizard_feature("Namer of the Unseen", f"""
 					You hunt names that have not yet been spoken: fate,
-					the hidden thread, tomorrow. The ten thousand things
-					announce themselves before they arrive, if you know
-					how to listen. You do not command the future. You
-					recognize its name when it leans toward you.
+					the hidden thread, tomorrow. You do not command the
+					future. You recognize its name when it leans toward you.
 					The name you hunt is <b>{sought_name}</b>.
 					""", 3),
 				savant,
@@ -486,40 +573,41 @@ class Wizard(Progression):
 		ward_hp = 2 * level + int_bonus
 		return [
 			wizard_feature("Namer of Binding", f"""
-				The uncarved block. The closed door. You hunt names that
-				hold: threshold, circle, iron, the center that does not
-				move. Power is not only what you send out. It is what you
-				refuse, what you keep, what you name as not-yet-broken.
+				You hunt names that hold: threshold, circle, iron, the
+				center that does not move. Power is not only what you send
+				out. It is what you refuse, what you keep.
 				The name you hunt is <b>{sought_name}</b>.
 				""", 3),
 			savant,
 			wizard_feature("Arcane Ward", f"""
 				When you cast an Abjuration spell with a spell slot, you
-				may write the Name of Binding around yourself. The ward
-				lasts until you finish a Long Rest. It has a Hit Point
-				maximum of <b>{ward_hp}</b> (twice your Wizard level plus
-				your Intelligence modifier).
+				may create a ward around yourself. The ward lasts until
+				you finish a Long Rest. It has a Hit Point maximum of
+				<b>{ward_hp}</b> (twice your Wizard level plus your
+				Intelligence modifier).
 				<br>Whenever you take damage, the ward takes it first.
 				If the ward drops to 0 Hit Points, you take the rest.
-				While it has 0 Hit Points it cannot absorb, but the
-				writing remains. Each time you cast an Abjuration spell
-				with a slot, the ward regains Hit Points equal to twice
-				that slot's level. You can create the ward only once
-				per Long Rest.
+				While it has 0 Hit Points it cannot absorb, but it remains.
+				Each time you cast an Abjuration spell with a slot, the
+				ward regains Hit Points equal to twice that slot's level.
+				You can create the ward only once per Long Rest.
 				""", 3),
 			]
 
 	def _tradition_level_six(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Bladesinger":
+			return [wizard_feature("Extra Attack", """
+				You can attack twice, instead of once, whenever you take
+				the Attack action. You may replace one of those attacks
+				with a Wizard cantrip that has a casting time of an action.
+				""", 6)]
 		if tradition == "Evoker":
 			return [wizard_feature("Sculpt Spells", f"""
 				When you cast an Evocation spell that other creatures you
-				can see would suffer, you may name a number of them equal
-				to 1 plus the spell's level as <i>not-this-fire</i>. Those
-				creatures automatically succeed on their saving throws
-				against the spell, and they take no damage if they would
-				normally take half on a success.
-				<br><i>The Name of {sought_name} does not strike what you
-				have named as kin.</i>
+				can see would suffer, you may choose a number of them equal
+				to 1 plus the spell's level. Those creatures automatically
+				succeed on their saving throws against the spell, and they
+				take no damage if they would normally take half on a success.
 				""", 6)]
 		if tradition == "Illusionist":
 			add_spells_to_book(character, find_spells(["Summon Beast", "Summon Fey"]))
@@ -530,11 +618,8 @@ class Wizard(Progression):
 				You always have <i>Summon Beast</i> and <i>Summon Fey</i>
 				prepared. Once per Long Rest you can cast one of them
 				without a spell slot; the summoned creature is slightly
-				translucent — a true-seeming, not a true body. When you
-				cast either spell with a spell slot, it does not require
-				Concentration.
-				<br><i>A name of seeming, spoken carefully, will wear a shape
-				until the shape remembers it is fog.</i>
+				translucent. When you cast either spell with a spell slot,
+				it does not require Concentration. See Spells.
 				""", 6)]
 		if tradition == "Necromancer":
 			add_spells_to_book(character, find_spells(["Animate Dead"]))
@@ -548,9 +633,7 @@ class Wizard(Progression):
 				Undead you create with a Necromancy spell add your Wizard
 				level (<b>+{thrall_hp}</b> Hit Points) to their Hit Point
 				maximum, and they add your Proficiency Bonus to the damage
-				of their weapon attacks.
-				<br><i>A last name, spoken kindly or not, will stand up
-				if you know how to hold it.</i>
+				of their weapon attacks. See Spells.
 				""", 6)]
 		if tradition == "Diviner":
 			return [wizard_feature("Expert Divination", """
@@ -558,27 +641,27 @@ class Wizard(Progression):
 				level 2 or higher, you regain one expended spell slot.
 				The regained slot must be of a lower level than the one
 				you spent, and it cannot be level 6 or higher.
-				<br><i>To see a name before it arrives is to spend less
-				breath when it does.</i>
 				""", 6)]
 		return [wizard_feature("Projected Ward", """
 			When a creature you can see within 30 feet takes damage, you
-			can take a Reaction to let your Arcane Ward drink that damage
+			can take a Reaction to let your Arcane Ward take that damage
 			instead. If the ward drops to 0 Hit Points, the creature takes
 			the rest.
-			<br><i>The Name of Binding can be spoken over someone else.
-			The center holds, even at a step's distance.</i>
 			""", 6)]
 
 	def _tradition_level_ten(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Bladesinger":
+			return [wizard_feature("Song of Defense", """
+				While your Bladesong is active and you take damage, you can
+				take a Reaction to expend a spell slot and reduce that
+				damage by an amount equal to five times the slot's level.
+				""", 10)]
 		if tradition == "Evoker":
 			bonus = max(1, int_bonus)
 			return [wizard_feature("Empowered Evocation", f"""
 				Whenever you cast a Wizard spell from the Evocation school,
 				you can add your Intelligence modifier (<b>+{bonus}</b>)
 				to one damage roll of that spell.
-				<br><i>You no longer borrow {sought_name}. It answers in
-				your own voice.</i>
 				""", 10)]
 		if tradition == "Illusionist":
 			return [wizard_feature("Illusory Self", """
@@ -587,15 +670,11 @@ class Wizard(Progression):
 				misses. Once you do this, you cannot do so again until you
 				finish a Short or Long Rest, unless you expend a spell slot
 				of level 2 or higher (no action) to restore the use.
-				<br><i>The name of you, and the you that is named, are not
-				always in the same place.</i>
 				""", 10)]
 		if tradition == "Necromancer":
 			return [wizard_feature("Inured to Undeath", """
 				You have Resistance to Necrotic damage, and your Hit Point
 				maximum cannot be reduced.
-				<br><i>You have heard the Name of Silence so often it no
-				longer startles your body.</i>
 				""", 10)]
 		if tradition == "Diviner":
 			uses = max(1, int_bonus)
@@ -622,12 +701,15 @@ class Wizard(Progression):
 			prepared. You can cast Dispel Magic as a Bonus Action, and you
 			add your Proficiency Bonus to its ability check.
 			When you cast either spell this way, your Arcane Ward regains
-			Hit Points equal to the spell's level.
-			<br><i>To unname a working is also a name. The ward drinks
-			what you take apart.</i>
+			Hit Points equal to the spell's level. See Spells.
 			""", 10)]
 
 	def _tradition_level_fourteen(self, character, tradition, lore, sought_name, level, int_bonus):
+		if tradition == "Bladesinger":
+			return [wizard_feature("Song of Victory", """
+				When you cast a spell with a casting time of an action,
+				you can make a melee weapon attack as a Bonus Action.
+				""", 14)]
 		if tradition == "Evoker":
 			return [wizard_feature("Overchannel", f"""
 				When you cast a Wizard spell with a spell slot of levels
@@ -639,9 +721,6 @@ class Wizard(Progression):
 				slot immediately after you cast it. This damage ignores
 				Resistance and Immunity. Each further use before a Long Rest
 				increases that Necrotic damage by <b>1d12</b> per spell level.
-				<br><i>Speak a name too completely and the unnamed Way takes
-				its due. {sought_name} is not a tool. It is a relationship,
-				and relationships burn.</i>
 				""", 14)]
 		if tradition == "Illusionist":
 			return [wizard_feature("Illusory Reality", """
@@ -649,8 +728,6 @@ class Wizard(Progression):
 				choose one inanimate, nonmagical object that is part of the
 				illusion and make that object real for 1 minute. The object
 				cannot deal damage or otherwise directly harm anyone.
-				<br><i>Seeming, held long enough in a true name, forgets
-				that it was only seeming. For a minute, the world agrees.</i>
 				""", 14)]
 		if tradition == "Necromancer":
 			return [wizard_feature("Command Undead", """
@@ -662,19 +739,13 @@ class Wizard(Progression):
 				your Command Undead for 24 hours. If it is already under
 				another creature's control, you steal that control on a
 				failure.
-				<br><i>A last name, once learned, can be spoken by more
-				than one throat. You make sure it is yours.</i>
 				""", 14)]
 		if tradition == "Diviner":
 			return [wizard_feature("Greater Portent", """
 				The unseen now offers three numbers instead of two when
 				you finish a Long Rest.
-				<br><i>The Pattern is not a chain. It is a braid, and you
-				have learned to hold a third strand.</i>
 				""", 14)]
 		return [wizard_feature("Spell Resistance", """
 			You have Advantage on saving throws against spells, and you
 			have Resistance to the damage of spells.
-			<br><i>Other people's names slide off the uncarved block.
-			You are harder to rewrite.</i>
 			""", 14)]

--- a/AtlasLusoris/Map_of_Classes/Training/Wizard.py
+++ b/AtlasLusoris/Map_of_Classes/Training/Wizard.py
@@ -204,32 +204,28 @@ def add_spells_to_book(character, spells):
 	return added
 
 
-def pick_savant_spells(tradition, wizard_level):
-	"""Savant: two school names of level 1–2, plus one per later slot level."""
+def pick_savant_spells(tradition, wizard_level, character=None):
+	"""Savant: two school names of level 1–2, plus one per later slot level. Grows; does not reshuffle."""
+	from AtlasLusoris.Compass_of_Learned_Spells import caster_rng
 	catalog = SAVANT_NAMES.get(tradition, {})
+	traditions = list(TRADITIONS.keys())
+	salt = 0x5A1 ^ (traditions.index(tradition) if tradition in traditions else 0)
+	rng = caster_rng(character, salt) if character is not None else random
 	picks = []
-	starter = list(catalog.get(1, [])) + list(catalog.get(2, []))
-	random.shuffle(starter)
-	picks.extend(starter[:2])
-	slot_levels = []
-	if wizard_level >= 5:
-		slot_levels.append(3)
-	if wizard_level >= 7:
-		slot_levels.append(4)
-	if wizard_level >= 9:
-		slot_levels.append(5)
-	if wizard_level >= 11:
-		slot_levels.append(6)
-	if wizard_level >= 13:
-		slot_levels.append(7)
-	if wizard_level >= 15:
-		slot_levels.append(8)
-	if wizard_level >= 17:
-		slot_levels.append(9)
-	for slot_level in slot_levels:
+	if wizard_level >= 3:
+		starter = list(catalog.get(1, [])) + list(catalog.get(2, []))
+		rng.shuffle(starter)
+		picks.extend(starter[:2])
+	slot_unlocks = [
+		(5, 3), (7, 4), (9, 5), (11, 6), (13, 7), (15, 8), (17, 9),
+		]
+	for req_level, slot_level in slot_unlocks:
+		if wizard_level < req_level:
+			continue
 		options = [name for name in catalog.get(slot_level, []) if name not in picks]
+		rng.shuffle(options)
 		if options:
-			picks.append(random.choice(options))
+			picks.append(options[0])
 	index = wizard_spell_index()
 	return [index[name] for name in picks if name in index], picks
 
@@ -393,7 +389,7 @@ class Wizard(Progression):
 
 	def _tradition_features(self, character, tradition, lore, sought_name, level, int_bonus):
 		school = lore["school"]
-		added_spells, pick_names = pick_savant_spells(tradition, level)
+		added_spells, pick_names = pick_savant_spells(tradition, level, character)
 		written = add_spells_to_book(character, added_spells)
 		written_line = ", ".join(written or pick_names[:2]) or f"two {school} spells"
 		savant = wizard_feature(f"{school} Savant", f"""
@@ -422,6 +418,9 @@ class Wizard(Progression):
 				]
 		if tradition == "Illusionist":
 			add_spells_to_book(character, find_spells(["Minor Illusion"]))
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
+			for spell in find_spells(["Minor Illusion"]):
+				grant_spell(character, spell)
 			return [
 				wizard_feature("Namer of Seeming", f"""
 					The named is not the thing. You hunt names of shadow,
@@ -524,6 +523,9 @@ class Wizard(Progression):
 				""", 6)]
 		if tradition == "Illusionist":
 			add_spells_to_book(character, find_spells(["Summon Beast", "Summon Fey"]))
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
+			for spell in find_spells(["Summon Beast", "Summon Fey"]):
+				grant_spell(character, spell)
 			return [wizard_feature("Phantasmal Creatures", """
 				You always have <i>Summon Beast</i> and <i>Summon Fey</i>
 				prepared. Once per Long Rest you can cast one of them
@@ -536,6 +538,9 @@ class Wizard(Progression):
 				""", 6)]
 		if tradition == "Necromancer":
 			add_spells_to_book(character, find_spells(["Animate Dead"]))
+			from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
+			for spell in find_spells(["Animate Dead"]):
+				grant_spell(character, spell)
 			thrall_hp = level
 			return [wizard_feature("Undead Thralls", f"""
 				You always have <i>Animate Dead</i> prepared. When you cast
@@ -609,6 +614,9 @@ class Wizard(Progression):
 				finish a Long Rest.
 				""", 10)]
 		add_spells_to_book(character, find_spells(["Counterspell", "Dispel Magic"]))
+		from AtlasLusoris.Compass_of_Learned_Spells import grant_spell
+		for spell in find_spells(["Counterspell", "Dispel Magic"]):
+			grant_spell(character, spell)
 		return [wizard_feature("Spell Breaker", """
 			You always have <i>Counterspell</i> and <i>Dispel Magic</i>
 			prepared. You can cast Dispel Magic as a Bonus Action, and you

--- a/AtlasLusoris/Map_of_Classes/__init__.py
+++ b/AtlasLusoris/Map_of_Classes/__init__.py
@@ -14,24 +14,29 @@ from .Codex_of_Progression  import (
 		apply_class_proficiencies
 		)
 
-# Import concrete classes
-try:
-	from .Training.Barbarian import Barbarian
-	from .Training.Bard      import Bard
-	from .Training.Cleric    import Cleric
-	from .Training.Druid     import Druid
-	from .Training.Fighter   import Fighter
-	from .Training.Monk      import Monk
-	from .Training.Paladin   import Paladin
-	from .Training.Ranger    import Ranger
-	from .Training.Rogue     import Rogue
-	from .Training.Sorcerer  import Sorcerer
-	from .Training.Warlock   import Warlock
-	from .Training.Wizard    import Wizard
-	from .Training.Multiclass import Multiclass
-except Exception as err:
-	# keep going, but make noise in logs
-	Warning(f"[Map_of_Classes]] could not load: {err}")
+# Import concrete classes independently so a missing file cannot hide the rest.
+def _load_training(name):
+	import importlib
+	try:
+		module = importlib.import_module(f".Training.{name}", __name__)
+		return getattr(module, name)
+	except Exception as err:
+		Warning(f"[Map_of_Classes] could not load {name}: {err}")
+		return None
+
+Barbarian = _load_training("Barbarian")
+Bard      = _load_training("Bard")
+Cleric    = _load_training("Cleric")
+Druid     = _load_training("Druid")
+Fighter   = _load_training("Fighter")
+Monk      = _load_training("Monk")
+Paladin   = _load_training("Paladin")
+Ranger    = _load_training("Ranger")
+Rogue     = _load_training("Rogue")
+Sorcerer  = _load_training("Sorcerer")
+Warlock   = _load_training("Warlock")
+Wizard    = _load_training("Wizard")
+Multiclass = _load_training("Multiclass")
 
 # ── backward-compat shim for Flask route ─────────────
 classes = list(CLASSES)        # same data, old variable name

--- a/AtlasLusoris/Map_of_Species.py
+++ b/AtlasLusoris/Map_of_Species.py
@@ -143,6 +143,12 @@ def species_features(species_name):
 			if lineage_choice == "Rock":
 				features.append(RockGnomeLineage())
 			return features
+	if species_name == "Tiefling":
+		return [
+			Darkvision(),
+			OtherworldlyPresence(),
+			FiendishLegacy(),
+			]
 	return species.get(species_name, [])
 
 

--- a/AtlasMagia/Lodge_of_Spells.py
+++ b/AtlasMagia/Lodge_of_Spells.py
@@ -146,6 +146,23 @@ if CANTRIPS:
 	Guidance =          Spell("Guidance",           0)
 	ThornWhip = 		Spell("Thorn Whip",			0)
 	PrimalSavagery =    Spell("Primal Savagery",    0)
+	Thunderclap =       Spell("Thunderclap",        0)
+	FireBolt =          Firebolt
+	Elementalism =      Spell("Elementalism",       0)
+	StarryWisp =        Spell("Starry Wisp",        0)
+	ArcaneVigor =       Spell("Arcane Vigor",       2)
+	AuraofVitality =    Spell("Aura of Vitality",   3)
+	SpeakWithPlants =   Spell("Speak with Plants",  3)
+	FountofMoonlight =  Spell("Fount of Moonlight", 4)
+	JallarziStormofRadiance = Spell("Jallarzi's Storm of Radiance", 5)
+	YolandeRegalPresence = Spell("Yolande's Regal Presence", 5)
+	TashasBubblingCauldron = Spell("Tasha's Bubbling Cauldron", 6)
+	Befuddlement =      Spell("Befuddlement",       8)
+	FlurryofBlows =     Spell("Flurry of Blows",    0)
+	PatientDefense =    Spell("Patient Defense",    0)
+	StepOfTheWind =     Spell("Step of the Wind",   0)
+	DeflectAttacks =    Spell("Deflect Attacks",    0)
+	StunningStrike =    Spell("Stunning Strike",    0)
 	# Rewrites
 
 

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -677,6 +677,46 @@ input[type="number"].fantasy-input {
 	z-index: -1; /* Place it behind text */
 }
 
+.spell-chip-rail {
+	text-align: left;
+	}
+.spell-chip-level {
+	font-family: 'Manufacturing Consent', 'Cinzel', serif;
+	font-size: 1.35em;
+	display: block;
+	margin: 0.45em 0 0.15em;
+	}
+.spell-chip-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25em 0.35em;
+	}
+.spell-chip,
+.spell-name {
+	font-family: 'Iglesia', 'IM Fell English', serif;
+	}
+.spell-chip {
+	display: inline-block;
+	font-size: 1.45em;
+	line-height: 1.2;
+	border: 1px solid #333;
+	border-radius: 999px;
+	padding: 0.05em 0.65em 0.12em;
+	background: var(--back-color);
+	}
+.spell-chip.spell-prepared,
+.spell-name.spell-prepared {
+	border-color: var(--primary-color);
+	}
+.spell-chip.spell-written,
+.spell-name.spell-written {
+	border-style: dashed;
+	color: #555;
+	}
+.spell-name {
+	font-size: 1.8em;
+	}
+
 /* Print-specific styles */
 @media print {
     .symbol {

--- a/app/templates/character.html
+++ b/app/templates/character.html
@@ -230,11 +230,10 @@
 
 
 
-			  <!-- Magic: rules first, full spell writeups last — same sheet order as genlegend.eu -->
+			  <!-- Magic: rules first, full spell writeups last -->
 			  {% if character.Spellcaster %}
 				    <div class="npc-textbox" style="grid-column: 1 / -1;">
 						<h1 style="font-family: 'Iglesia'; font-size: 2.8em;">Magic</h1>
-						<p>【prepared / always available】 &nbsp; 〖written or granted, not prepared】</p>
 						</div>
 				    {{ character.Spellcaster.html() | safe }}
 				    {{ character.Spellcaster.html_catalog() | safe }}

--- a/app/templates/character.html
+++ b/app/templates/character.html
@@ -230,9 +230,14 @@
 
 
 
-			  <!-- Spellcasting -->
+			  <!-- Magic: rules first, full spell writeups last — same sheet order as genlegend.eu -->
 			  {% if character.Spellcaster %}
+				    <div class="npc-textbox" style="grid-column: 1 / -1;">
+						<h1 style="font-family: 'Iglesia'; font-size: 2.8em;">Magic</h1>
+						<p>【prepared / always available】 &nbsp; 〖written or granted, not prepared】</p>
+						</div>
 				    {{ character.Spellcaster.html() | safe }}
+				    {{ character.Spellcaster.html_catalog() | safe }}
 					{% endif %}
 	</div>
 

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -189,6 +189,40 @@ def test_2024_casting_tables():
 	assert casting_row("Druid", 18)["slots"][4] == 2
 
 
+def test_chthonic_fiendish_legacy_copy():
+	from AtlasLusoris.Grimoire_of_Features import CHTHONIC_FLAVOR, FiendishLegacy
+
+	class Character:
+		spellcaster = None
+		char_class = "Wizard"
+		level = 1
+		features = []
+
+	character = Character()
+	feat = FiendishLegacy("Chthonic")
+	feat(character)
+	assert feat.name == "Fiendish Legacy: Chthonic"
+	assert f"<i>{CHTHONIC_FLAVOR}</i>" in feat.description
+	assert "Hades' gates are said to be guarded by grim dogs with several heads" in feat.description
+	assert "<b>Intelligence</b> is your spellcasting ability." in feat.description
+	assert "for them" not in feat.description
+	assert "Chill Touch" in {
+		spell_key(spell) for spell in catalog_spells(character.spellcaster)
+		}
+	assert "False Life" not in {
+		spell_key(spell) for spell in catalog_spells(character.spellcaster)
+		}
+
+
+def test_tiefling_species_grants_presence_and_legacy():
+	from AtlasLusoris.Map_of_Species import species_features
+
+	names = {feat.name for feat in species_features("Tiefling")}
+	assert any(name.startswith("Darkvision") for name in names)
+	assert "Otherworldly Presence" in names
+	assert any(name.startswith("Fiendish Legacy:") for name in names)
+
+
 if __name__ == "__main__":
 	test_grows_without_reshuffle()
 	test_know_spell_is_separate_from_display()
@@ -198,5 +232,7 @@ if __name__ == "__main__":
 	test_progressive_learn_skips_owned_names_without_shrinking_the_budget()
 	test_spell_index_uses_level_chips()
 	test_2024_casting_tables()
+	test_chthonic_fiendish_legacy_copy()
+	test_tiefling_species_grants_presence_and_legacy()
 	print("progressive_learn: ok", flush=True)
 	os._exit(0)

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -1,7 +1,11 @@
 """Learned spells grow with level and do not reshuffle."""
 from AtlasLusoris.Compass_of_Learned_Spells import (
+	catalog_spells,
+	html_spell_catalog,
+	know_spell,
 	progressive_learn,
 	spell_key,
+	spell_mark,
 	unique_spells,
 	)
 
@@ -47,6 +51,41 @@ def test_grows_without_reshuffle():
 	assert len(unique_spells(low_known)) == len(low_known)
 
 
+def test_know_spell_is_separate_from_display():
+	class Character:
+		spellcaster = None
+
+	character = Character()
+	spell = FakeSpell("Speak with Animals", 1)
+	gained = know_spell(character, spell)
+	assert gained is None
+	known = catalog_spells(character.spellcaster)
+	assert {spell_key(item) for item in known} == {"Speak with Animals"}
+	page = html_spell_catalog(character.spellcaster)
+	assert "Speak with Animals" in page
+	assert spell_mark(spell) in page
+
+
+def test_forest_gnome_lineage_knows_without_embedding():
+	from AtlasLusoris.Grimoire_of_Features import ForestGnomeLineage
+
+	class Character:
+		spellcaster = None
+		features = []
+
+	character = Character()
+	feat = ForestGnomeLineage()
+	feat(character)
+	names = {spell_key(spell) for spell in catalog_spells(character.spellcaster)}
+	assert "Minor Illusion" in names
+	assert "Speak with Animals" in names
+	assert "<div class='npc-textbox'>" not in feat.description
+	assert "{SpeakwithAnimals}" not in feat.description
+	assert str(character.spellcaster.html_catalog()).count("Speak with Animals") >= 1
+
+
 if __name__ == "__main__":
 	test_grows_without_reshuffle()
+	test_know_spell_is_separate_from_display()
+	test_forest_gnome_lineage_knows_without_embedding()
 	print("progressive_learn: ok")

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -4,6 +4,7 @@ from AtlasLusoris.Compass_of_Learned_Spells import (
 	catalog_keys,
 	catalog_spells,
 	html_spell_catalog,
+	html_spell_index,
 	know_spell,
 	progressive_learn,
 	spell_key,
@@ -160,6 +161,34 @@ def test_progressive_learn_skips_owned_names_without_shrinking_the_budget():
 	assert len(known) == 4
 
 
+def test_spell_index_uses_level_chips():
+	class Book:
+		spells_known = [FakeSpell("Fire Bolt", 0), FakeSpell("Shield", 1)]
+		granted_spells = []
+		always_prepared = set()
+		prepared_spells = [FakeSpell("Fire Bolt", 0)]
+		catalog_known = True
+
+	page = html_spell_index(Book())
+	assert "spell-chip-rail" in page
+	assert "Cantrips" in page
+	assert "Level 1" in page
+	assert "Fire Bolt" in page
+	assert "【" not in page
+
+
+def test_2024_casting_tables():
+	from AtlasLusoris.Map_of_Casting_Tables import casting_row
+	assert casting_row("Sorcerer", 1)["prepared"] == 2
+	assert casting_row("Sorcerer", 1)["cantrips"] == 4
+	assert casting_row("Sorcerer", 20)["prepared"] == 22
+	assert casting_row("Sorcerer", 20)["slots"][5] == 2
+	assert casting_row("Wizard", 1)["prepared"] == 4
+	assert casting_row("Warlock", 1)["prepared"] == 2
+	assert casting_row("Ranger", 9)["prepared"] == 8
+	assert casting_row("Druid", 18)["slots"][4] == 2
+
+
 if __name__ == "__main__":
 	test_grows_without_reshuffle()
 	test_know_spell_is_separate_from_display()
@@ -167,5 +196,7 @@ if __name__ == "__main__":
 	test_wildwarden_knows_speak_with_animals_without_embedding()
 	test_grant_does_not_consume_a_class_known_slot()
 	test_progressive_learn_skips_owned_names_without_shrinking_the_budget()
+	test_spell_index_uses_level_chips()
+	test_2024_casting_tables()
 	print("progressive_learn: ok", flush=True)
 	os._exit(0)

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -1,5 +1,7 @@
 """Learned spells grow with level and do not reshuffle."""
+import os
 from AtlasLusoris.Compass_of_Learned_Spells import (
+	catalog_keys,
 	catalog_spells,
 	html_spell_catalog,
 	know_spell,
@@ -101,6 +103,61 @@ def test_wildwarden_knows_speak_with_animals_without_embedding():
 	assert "See Spells" in feat.description
 	assert "Tag Team" in feat.description
 	assert str(character.spellcaster.html_catalog()).count("Speak with Animals") >= 1
+	assert "Speak with Animals" not in {
+		spell_key(spell) for spell in character.spellcaster.spells_known
+		}
+
+
+def test_grant_does_not_consume_a_class_known_slot():
+	speak = FakeSpell("Speak with Animals", 1)
+	fire = FakeSpell("Fire Bolt", 0)
+	shield = FakeSpell("Shield", 1)
+	armor = FakeSpell("Mage Armor", 1)
+
+	class Book:
+		def __init__(self):
+			self.spells_known = [speak, fire]
+			self.granted_spells = []
+			self.always_prepared = set()
+			self.prepared_spells = [speak, fire]
+			self.catalog_known = True
+			self.spells_available = [speak, fire, shield, armor]
+
+	class Character:
+		def __init__(self):
+			self.seed = 7
+			self.spellcaster = Book()
+
+	character = Character()
+	known_before = len(character.spellcaster.spells_known)
+	know_spell(character, speak)
+	book = character.spellcaster
+	granted_names = {spell_key(spell) for spell in book.granted_spells}
+	known_names = {spell_key(spell) for spell in book.spells_known}
+	assert granted_names == {"Speak with Animals"}
+	assert "Speak with Animals" not in known_names
+	assert len(book.spells_known) == known_before
+	assert {"Speak with Animals", "Fire Bolt"} <= catalog_keys(book)
+	know_spell(character, speak)
+	assert len([spell for spell in book.granted_spells if spell_key(spell) == "Speak with Animals"]) == 1
+
+
+def test_progressive_learn_skips_owned_names_without_shrinking_the_budget():
+	cantrips, known = progressive_learn(
+		FakeCharacter(42),
+		fake_table(),
+		1,
+		cantrips_at=lambda lvl: 3,
+		known_at=lambda lvl: 4,
+		slots_at=lambda lvl: (2,),
+		salt=1,
+		skip={"Cantrip 1", "First 1"},
+		)
+	keys = {spell_key(spell) for spell in cantrips + known}
+	assert "Cantrip 1" not in keys
+	assert "First 1" not in keys
+	assert len(cantrips) == 3
+	assert len(known) == 4
 
 
 if __name__ == "__main__":
@@ -108,4 +165,7 @@ if __name__ == "__main__":
 	test_know_spell_is_separate_from_display()
 	test_forest_gnome_lineage_knows_without_embedding()
 	test_wildwarden_knows_speak_with_animals_without_embedding()
-	print("progressive_learn: ok")
+	test_grant_does_not_consume_a_class_known_slot()
+	test_progressive_learn_skips_owned_names_without_shrinking_the_budget()
+	print("progressive_learn: ok", flush=True)
+	os._exit(0)

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -84,8 +84,28 @@ def test_forest_gnome_lineage_knows_without_embedding():
 	assert str(character.spellcaster.html_catalog()).count("Speak with Animals") >= 1
 
 
+def test_wildwarden_knows_speak_with_animals_without_embedding():
+	from AtlasLusoris.Grimoire_of_Features import Wildwarden
+
+	class Character:
+		spellcaster = None
+		char_class = "Wizard"
+		features = []
+
+	character = Character()
+	feat = Wildwarden()
+	feat(character)
+	names = {spell_key(spell) for spell in catalog_spells(character.spellcaster)}
+	assert "Speak with Animals" in names
+	assert "<div class='npc-textbox'>" not in feat.description
+	assert "See Spells" in feat.description
+	assert "Tag Team" in feat.description
+	assert str(character.spellcaster.html_catalog()).count("Speak with Animals") >= 1
+
+
 if __name__ == "__main__":
 	test_grows_without_reshuffle()
 	test_know_spell_is_separate_from_display()
 	test_forest_gnome_lineage_knows_without_embedding()
+	test_wildwarden_knows_speak_with_animals_without_embedding()
 	print("progressive_learn: ok")

--- a/tests/test_learned_spells.py
+++ b/tests/test_learned_spells.py
@@ -1,0 +1,52 @@
+"""Learned spells grow with level and do not reshuffle."""
+from AtlasLusoris.Compass_of_Learned_Spells import (
+	progressive_learn,
+	spell_key,
+	unique_spells,
+	)
+
+
+class FakeSpell:
+	def __init__(self, name, level):
+		self.name = name
+		self.level = level
+
+
+def fake_table():
+	return {
+		0: [FakeSpell(f"Cantrip {i}", 0) for i in range(1, 9)],
+		1: [FakeSpell(f"First {i}", 1) for i in range(1, 9)],
+		2: [FakeSpell(f"Second {i}", 2) for i in range(1, 9)],
+		3: [FakeSpell(f"Third {i}", 3) for i in range(1, 9)],
+		}
+
+
+class FakeCharacter:
+	def __init__(self, seed):
+		self.seed = seed
+
+
+def learn_at(level):
+	return progressive_learn(
+		FakeCharacter(42),
+		fake_table(),
+		level,
+		cantrips_at=lambda lvl: 3 if lvl < 4 else 4,
+		known_at=lambda lvl: 4 + lvl,
+		slots_at=lambda lvl: (2, 0, 0) if lvl < 3 else (4, 2, 0) if lvl < 5 else (4, 3, 2),
+		salt=1,
+		)
+
+
+def test_grows_without_reshuffle():
+	low_cantrips, low_known = learn_at(4)
+	high_cantrips, high_known = learn_at(5)
+	assert {spell_key(spell) for spell in low_cantrips} <= {spell_key(spell) for spell in high_cantrips}
+	assert {spell_key(spell) for spell in low_known} <= {spell_key(spell) for spell in high_known}
+	assert len(high_known) >= len(low_known)
+	assert len(unique_spells(low_known)) == len(low_known)
+
+
+if __name__ == "__main__":
+	test_grows_without_reshuffle()
+	print("progressive_learn: ok")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Learned spells stay put as the ± buttons raise the level. Spell writeups live at the end.

## Accessible, known, and granted

A feature that teaches a spell does not eat a class known slot.

- **Accessible** — the class list (`spells_available`). The pool, not a budget.
- **Known** — class-progression picks (`spells_known`).
- **Granted** — feats, species, invocations, extra cantrips (`granted_spells`).

## 2024 tables and the spell rail

Cantrips / prepared / slots for Wizard, Sorcerer, Druid, Ranger, and Warlock now follow the 2024 PHB columns. Sorcerer currently inherits the Wizard spell list until we tag a real Sorcerer list. The Magic block lists spells as chips by cantrip and slot level, in Iglesia. Monk Focus stays in Magic.

## Tiefling Fiendish Legacy

Tieflings now get Darkvision, Otherworldly Presence, and a Fiendish Legacy (Abyssal, Chthonic, or Infernal). Chthonic uses your flavor line in italics:

> Hades' gates are said to be guarded by grim dogs with several heads, strange faceless minotaurs, and foxes with a multitude of tails. You find it hard to imagine how you may be related to them.

The spellcasting line is **Intelligence** (or Wisdom / Charisma from the class) **is your spellcasting ability.** — no “for them.” Abyssal and Infernal have the 2024 mechanics only; no flavor was written for them.

## Wizard flavor is not decided

Copy such as “The Way of Names” and “Namer of …” is in this branch from earlier agent work. It is not on genlegend.eu and it is not signed off. Keep, cut, or rewrite is yours.

## Wildwarden

Wildkeeper is a background. Wildwarden is its origin feat. Speak with Animals is granted and shown in the Spells catalog.

genlegend.eu is a testing reference, not a frozen layout.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d45942c4-1760-4693-9462-3ba39f6a0a09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d45942c4-1760-4693-9462-3ba39f6a0a09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

