### PR TITLE
The Dwarf review opens: two defects fixed, four Questae filed

### DIFF
--- a/AtlasActorLudi/SpeciesKit/Dwarves/resolution.py
+++ b/AtlasActorLudi/SpeciesKit/Dwarves/resolution.py
@@ -117,7 +117,7 @@ def _project_stonecunning(
 			f"range of {Stonecunning.RANGE} feet for "
 			f"{Stonecunning.DURATION_MINUTES} minutes. You must be on a stone "
 			f"surface or touching a stone surface to use this "
-			f"{Stonecunning.SENSE}. The stone can be natural or worked. You can "
+			f"{Stonecunning.ACTION}. The stone can be natural or worked. You can "
 			f"use this {Stonecunning.ACTION} a number of times equal to your "
 			f"Proficiency Bonus ({proficiency}), and you regain all expended "
 			f"uses when you finish a {Stonecunning.RECOVERY}."

--- a/AtlasActorLudi/SpeciesKit/Dwarves/traits.py
+++ b/AtlasActorLudi/SpeciesKit/Dwarves/traits.py
@@ -92,23 +92,6 @@ class Dwarven_Toughness(Trait):
 		target.bonus_health_per_level = sum(
 			sources.values()
 			)
-		# Granted, not merely recorded.  Contributions are kept by name so that
-		# re-imprinting cannot double them and a second source cannot silently
-		# replace the first: the sheet reads the sum.
-		sources = dict(
-			getattr(
-				target,
-				"bonus_health_sources",
-				{},
-				) or {}
-			)
-		sources[
-			"Dwarven Toughness"
-			] = Dwarven_Toughness.HIT_POINTS_PER_LEVEL
-		target.bonus_health_sources = sources
-		target.bonus_health_per_level = sum(
-			sources.values()
-			)
 
 
 class Stonecunning(Trait):

--- a/Documenta/Questae/Open/QST-0116-the-dwarf-page-against-itself.md
+++ b/Documenta/Questae/Open/QST-0116-the-dwarf-page-against-itself.md
@@ -1,0 +1,126 @@
+# QST-0116 — Five places where the Dwarf page contradicts itself or the code
+
+- **Type:** lore / copy
+- **Priority:** 🟠 high
+- **Status:** Open
+- **Owner:** Julio (only)
+- **Route to:** Julio · Lorekeeper
+- **Related:** QST-0094 · QST-0117 · QST-0118 · QST-0119 · `Documenta/Canon/Mythos/Dwarf.md` · `Documenta/Canon/Mythos/Aasimar.md` (locked)
+
+> Opened 2026-09-12, first pass of the Dwarf review, run the way the Aasimar was
+> run: every claim read out of the implementation rather than from memory.
+> Nothing on the page was edited. Only Julio edits a book.
+
+---
+
+## 🔍 Diagnosis (what & where)
+
+The Dwarf page is the second-best chapter 0 in the folder and it already knows
+most of what is wrong with it: §0's *Unratified* list is fifteen items long and
+honest. These five are different. They are places where the page disagrees with
+**itself**, or with a page that is already locked, so no ratification is needed
+to settle them. Somebody just has to pick the surviving sentence.
+
+**1. §2 calls Darkvision "the deepest on the roster". §0 forbids exactly that
+sentence, and the code agrees with §0.**
+
+§0 states it plainly:
+
+> the ranking the page has been making is wrong: 120 feet is the longest range on
+> the roster but not the Dwarf's alone [...] Whatever is written must say "as
+> deep as anyone's", never "the deepest".
+
+§2 then writes it anyway:
+
+> **Physical traits.** Darkvision to 120 feet (the deepest on the roster) [...]
+
+The code settles the fact. `Dwarves/traits.py:12` is 120; so is `Orcs/traits.py:37`;
+so are `Elves/Drow.py:19`, `Elves/Dark_Elf.py:19` and `Elves/Shadow_Elf.py:26`.
+Five ranges tie. §2 is the defect, and it is one parenthesis wide.
+
+**2. The Dwarven Resilience line exists in two wordings, and they disagree.**
+
+| Where | The line |
+|---|---|
+| §0, under the rule | *Every dwarf grows up tasting the mine air and the smelter's fumes. What did not kill your people taught them.* |
+| §9, the ratification table | *Every dwarf grows up tasting the mine air and the smelter's fumes. What did not kill our ancestors does not poison us.* |
+
+QST-0094 proposed the §9 wording. Somebody rewrote the second sentence when it
+was carried into §0, and the two copies have sat side by side since. They are
+not the same claim: *taught them* is the taught-not-inherited law speaking, and
+*does not poison us* is the mechanic restated, which For-Reviewers §7 rule 1
+spends the sentence on. The other three lines are identical in both places.
+
+QST-0117 cannot wire four lines while one of them is two lines.
+
+**3. §3 quotes the species entry, and the quotation is not what the entry says.**
+
+§3 opens on what reads as a verbatim quotation:
+
+> *"Our people ruled the world once. Then the Great Mountain fell, the Gilded Era
+> ended with it [...]"*
+
+`Dwarves/__init__.py:19` says **Guilded** Era. §0 already flags the spelling in
+its *Unratified* list, so the page knows; §3 quietly corrects it inside quotation
+marks, which is the one place a page may not correct anything. Either the entry's
+spelling is a typo and the code changes, or *Guilded* is the joke (a guild era
+that was also gilded, which for this people would be a good joke) and §3 must
+quote it. It cannot be both.
+
+**4. §2's list of the Aasimar's metals is three short, and the Aasimar page is
+locked.**
+
+§2 reads:
+
+> The Aasimar's talaria shine like metals (black iron, gold, red iron, silver,
+> verdigris, bronze) and confirm nothing
+
+`Aasimar.md` §0 tables nine Ideals, and the metal column now holds **black iron,
+gold, red iron, silver, verdigris, pearl, tin, bronze, brass**. Tin arrived with
+Hope's laurel and brass with Harmony (QST-0111). Pearl is not a metal and never
+was, which is worth a decision of its own, but the Dwarf page is missing tin and
+brass either way. A locked page outranks an unlocked one, so this is the Dwarf's
+sentence to update, not the Aasimar's table.
+
+**5. §0 accuses §8 of an error, and §0 is the one that is stale.**
+
+§0's *Unratified* list, on Darkvision:
+
+> The decisions log in §8 is wrong here and should be corrected now: QST-0094
+> records the Aasimar as chip-only by design and lists the convention as still
+> open (Elf, Orc, Gnome, Dwarf and Tiefling print the rule; Aasimar and
+> Dragonborn print the chip)
+
+QST-0094 has not said that since 2026-09-11. It now reads:
+
+> Elf, Orc, Gnome, Dwarf, Tiefling and now **Aasimar** print the rule under an
+> italic line [...] **Dragonborn is the last one printing a bare chip**, and it is
+> the whole of what is left of this question
+
+And §8, the log being accused, already carries the current reading: *"settled
+print, with a line for the Aasimar, which settles the convention if applied
+here."* So §8 is right, §0 is quoting a ticket that has moved, and the
+instruction to correct §8 should be struck rather than followed.
+
+What is actually left of this for the Dwarf is small and worth stating as
+decided. The Aasimar's settled shape is **rule, line, chip**. The Dwarf prints
+rule and chip and no line, so once QST-0117 lands the four lines the Dwarf holds
+the same shape as the locked page, and the open half of the question belongs to
+the Dragonborn and not to this page at all. §8's row can move from *Awaiting
+ratification* to *Decided*.
+
+## 🎯 Desired outcome
+
+Julio rules on each. All five are page-only, and four of the five are one
+sentence:
+
+1. §2 loses *"the deepest on the roster"* for §0's *"as deep as anyone's"*.
+2. One Resilience line survives. QST-0117 wires whichever it is.
+3. *Guilded* or *Gilded*, once, and §3 quotes what the code says.
+4. §2's metals follow the locked table, and pearl is called what it is.
+5. §0's Darkvision paragraph is restated against the current QST-0094, and §8's
+   row moves to *Decided*.
+
+## 🧭 Note
+
+Item 2 is the only one that reaches the sheet, and it blocks QST-0117.

--- a/Documenta/Questae/Open/QST-0118-two-leftovers-in-the-dwarf-kit.md
+++ b/Documenta/Questae/Open/QST-0118-two-leftovers-in-the-dwarf-kit.md
@@ -1,0 +1,70 @@
+# QST-0118 — Two leftovers in the Dwarf kit, and one of them disagrees
+
+- **Type:** code / hygiene
+- **Priority:** 🟡 normal *(one of the two can mislead a later hand)*
+- **Status:** Open
+- **Owner:** unclaimed
+- **Route to:** Technical Team · Julio (item 2 is authored text)
+- **Related:** QST-0115 (the same sweep on the Aasimar) · QST-0091.1 (Species: one file) · QST-0072 (recovery) · QST-0117
+
+---
+
+## 🔍 Diagnosis (what & where)
+
+Two files found reading `SpeciesKit/Dwarves/` against the page. Neither is
+visible on a sheet, so neither was folded into QST-0117. The second is worse
+than the Aasimar's equivalent and should not be treated as the same ticket twice.
+
+**1. `AtlasActorLudi/SpeciesKit/Dwarves.py` is dead, and it defines a second
+`Dwarf`.**
+
+The flat module and the `Dwarves/` package sit in the same directory. Python
+resolves the package, so every importer gets the package: `SpeciesKit/__init__.py:68`,
+`catalog.py:9`, `resolution.py:102`. Nothing reaches the flat file at all.
+
+It is not an empty stub. It declares its own `class Dwarf(Species, Humanoid)`
+with a docstring (*"A resilient Humanoid with an affinity for stone"*), its own
+`Set_Physiology`, and its own `Player_Handbook_2024` registration with the same
+weight, size and speed. What it does **not** have is the four traits. A later
+hand who finds it, reads it, and adds a trait there will have written correct
+code that changes nothing on any sheet, and the search that would explain why is
+the one nobody runs. `Dragonborn.py` is in the same state; every other package
+species (Aasimar, Elves, Gnomes, Goliaths, Halflings, Orcs, Tieflings) has no
+flat twin, so these two are the residue of QST-0091.1 rather than a convention.
+
+**2. `Dwarves/__init__.py.source-partial` is an older draft of the species
+entry, not a copy of it.**
+
+QST-0115 found the Aasimar's `.source-partial` byte-identical to its
+`__init__.py` and left it because deleting a tracked file is not a thing to do in
+passing. The Dwarf's is **different text**, and the difference is the exact thing
+QST-0094 decided:
+
+| | `__init__.py` (shipping) | `.source-partial` |
+|---|---|---|
+| Voice | *"Dwarves. **We** remember. **Our** people ruled the world once."* | *"Dwarves. **They** remember. **Your** people ruled the world once."* |
+| Metal | *"Metal is holy to **our** people. Everything **we** dwarves ever built, **we** built..."* | *"Metal is holy to **your** people. Everything the dwarves ever built, **they** built..."* |
+| Greed | *"They do not understand. Gold never corrupts."* | *"**Greed is not the only reason.** Gold never corrupts."* |
+
+So the repository tracks, beside the ratified first-person entry, a full
+second-person alternative with a sentence the shipping text does not contain.
+Nothing imports it and nothing ever will, because the name is not a module name.
+It reads as a source of truth and it is not one. That is the failure mode
+QST-0115 named for `glow_from`: *a field that states something the generator does
+not do is worse than absent, because a later hand will trust it.*
+
+## 🎯 Desired outcome
+
+1. `SpeciesKit/Dwarves.py` leaves the tree, and `Dragonborn.py` with it if the
+   same reading holds there. Under QST-0091.1 the package is the one file.
+2. `.source-partial` leaves the index. Before it does, Julio reads the three rows
+   above once: *"Greed is not the only reason"* is a sentence that was written and
+   then dropped, and this ticket is the last place it exists. If it is wanted, it
+   belongs in the entry or on `Dwarf.md`, not in an unimported file.
+
+## 🧭 Note
+
+Deleting tracked files is the kind of change this project has been burned by
+(QST-0072, and the whole `.recovery-vault`). Both deletions are one commit, they
+are provable (no importer, no module name), and they should be their own commit
+with nothing else in it.

--- a/Documenta/Questae/Open/QST-0119-shared-rule-text-has-no-single-home.md
+++ b/Documenta/Questae/Open/QST-0119-shared-rule-text-has-no-single-home.md
@@ -1,0 +1,102 @@
+# QST-0119 — Shared rule text has no single home, and the lock does not check rules
+
+- **Type:** design / process
+- **Priority:** 🟠 high *(it decides what "locked" is worth, for every species after the Aasimar)*
+- **Status:** Open
+- **Owner:** Julio (the ruling) · Technical Team (the script)
+- **Route to:** Julio · Lorekeeper · Technical Team
+- **Related:** QST-0113 · QST-0116 · QST-0117 · QST-0094 · `scripts/verify_aasimar_page.py` · `AtlasActorLudi/SpeciesKit/traits.py::Darkvision_Rules`
+
+> Found while running the Dwarf review the way the Aasimar was run. It is not a
+> Dwarf finding. It is the first thing the Aasimar's method hits when a second
+> species tries to use it, so it should be settled before a third page is locked.
+
+---
+
+## 🔍 Diagnosis (what & where)
+
+`README.md` states the protocol: **a book means locked, and the code adapts to
+the book.** `Aasimar.md` is the worked reference and carries the first lock.
+`scripts/verify_aasimar_page.py` exists so the claim is mechanical rather than
+asserted, and it passes.
+
+Two things are true at the same time, and together they are the problem.
+
+**1. Darkvision's rule text exists in three wordings, one of them on a locked
+page.**
+
+| Source | The Darkness clause |
+|---|---|
+| `traits.py::Darkvision_Rules` (what prints, for every species) | *In Darkness within that range you can see as if it were Dim Light **(**you have Disadvantage on Wisdom (Perception) checks that rely on sight, and **colors are only** shades of gray**)**.* |
+| `Aasimar.md` §0 (**locked**) | *In Darkness within that range you **see** as if it were Dim Light**:** you have Disadvantage on Wisdom (Perception) checks that rely on sight, and **you discern colors there only as** shades of gray.* |
+| `Dwarf.md` §0 | *In Darkness within that range you can see as if it were Dim Light**:** **within that Darkness** you have Disadvantage [...] and you discern colors there only as shades of gray.* |
+
+The Dwarf page also opens its entry with *"You have Darkvision with a range of
+120 feet"*, a sentence the code never prints.
+
+By the protocol, the locked page wins and `Darkvision_Rules` is a defect. But
+`Darkvision_Rules` is **shared**: the Aasimar, the Dwarf, the Elf, the Orc, the
+Gnome and the Tiefling all print the same function's output at their own range,
+and its docstring is a careful piece of work that explains why each of the three
+scopes is load-bearing. Adapting it to the Aasimar's colon rewords six species'
+sheets to satisfy one page. Adapting it to the Dwarf's is the same move in the
+other direction. **One shared function cannot satisfy two differently worded
+locked pages, and there are eight species pages left to lock.**
+
+**2. The verify script does not check a single rule.**
+
+It checks the player-facing description byte for byte, that the eight lines reach
+`resolution.py`, the nine Ideals row by row, the eight perches, the eleven
+plumages, and Size, Size weighting and Speed. It never compares a rule text.
+
+That is precisely the hole QST-0113 fell through the first time: of the defects it
+found, **three were drifted rule texts** inside Celestial Revelation, not lines,
+and the script written afterwards would not have caught any of the three. It
+would catch them re-drifting today only because the option paragraphs happen to
+contain their lines. So the lock currently proves the lore and the tables, and
+takes the rules on trust, which is the opposite of where the risk is: a line is
+authored once and left alone, and a rule is edited every time a constant moves.
+
+## 🎯 Desired outcome
+
+Julio rules on the first; the second follows from it.
+
+**A. Where does shared rule text live?** Three candidates, and this ticket does
+not prefer one:
+
+1. **One text, quoted.** `Darkvision_Rules` is the single source, and every
+   species page quotes it verbatim at its own range. Pages stop paraphrasing
+   rules that are not theirs. Cheapest to verify: the check becomes
+   `Darkvision_Rules(range) in page`.
+2. **One text per species.** Each page owns its wording and the shared helper
+   becomes a default that species with a page override. Most faithful to "the
+   page is the authority"; it also means six near-identical strings, and the
+   docstring's three scopes have to survive in each.
+3. **The page states the rule, the code states the sheet.** A 📕 entry is written
+   for a reviewer resolving it at a table, and the sheet is written for a player,
+   and they are allowed to differ in wording but never in effect. This is the only
+   option that survives the *second* case below, and it costs the byte-for-byte
+   check.
+
+**The second case, because it decides between them.** `Dwarf.md` §0 writes
+Stonecunning's allowance as the whole table, *"a number of times equal to your
+Proficiency Bonus (2 at Levels 1-4, 3 at 5-8, 4 at 9-12, 5 at 13-16, 6 at
+17-20)"*. The sheet prints the resolved number for the character holding it,
+*"(3)"*. For-Reviewers rule 8 says **a sheet prints resolved numbers rather than
+formulas**, so here the code is right and the page is wrong, and "the code adapts
+to the page" would be a regression. The Aasimar avoided this by inventing a
+notation instead: its legend declares *"Curly brackets {} represent the resolution
+of the calculation"* and its rules read **{PB}d4** and **DC {8 + PB + CHA}**. That
+convention is on one page and in no standing rule. If option 1 or 2 is chosen,
+the brace notation has to become a folder-wide rule and the Dwarf page has to
+adopt it.
+
+**B. The script grows a rules check**, whichever way A goes, and becomes
+`scripts/verify_species_page.py` taking a species name, so the tenth page costs
+an argument rather than a file. Its Aasimar behaviour must not change.
+
+## 🧭 Note
+
+Nothing here says the Aasimar lock was wrong. It says the lock proves what was
+hard to get right *once* and not what is easy to get wrong *repeatedly*, and that
+the second species is the right moment to find that out rather than the ninth.

--- a/Documenta/Questae/Working/QST-0117-the-dwarfs-four-entries-match-the-page.md
+++ b/Documenta/Questae/Working/QST-0117-the-dwarfs-four-entries-match-the-page.md
@@ -1,0 +1,104 @@
+# QST-0117 — The Dwarf's four entries, as the page states them
+
+- **Type:** code / lore-fidelity
+- **Priority:** 🟠 high *(user-visible sheet text)*
+- **Status:** Working (the two defects landed; the four lines await Julio)
+- **Owner:** Claude
+- **Route to:** Technical Team · Lorekeeper · Julio
+- **Parent:** QST-0094
+- **Related:** QST-0113 (the same work on the Aasimar) · QST-0116 · QST-0119 · `Documenta/Canon/Mythos/Dwarf.md` §0 · `AtlasActorLudi/SpeciesKit/Dwarves/`
+
+---
+
+## 🔍 Diagnosis (what & where)
+
+`Dwarf.md` §0 states four rules and four lines. The sheet carries the four rules
+and none of the lines. Read off a generated Dwarf at levels 1 and 5, projected
+through `Resolve_Dwarf_Features`, 2026-09-12.
+
+**1. Not one of the four lines reaches the sheet.**
+
+The Aasimar's eight were wired on 2026-09-11 (QST-0113) in the house format:
+`*line*`, a blank line, then the rule. The Dwarf's four are authored, sit on the
+page under their rules, and are marked *(authored, not wired)* there. Nothing
+projects them, so a Dwarf sheet is four paragraphs of rulebook and no voice.
+
+Read across the roster, 2026-09-12: the Aasimar, Elf, Halfling, Orc and
+Dragonborn print an italic line; the Gnome and the Goliath print authored prose
+instead, which QST-0094 recorded as the second convention; **the Dwarf and the
+Tiefling print neither.** The two are not in the same position, though, and that
+is the point of this ticket. The Tiefling's lines have never been written. The
+Dwarf's are written, sit on its page, and are one commit of four strings away.
+
+| Entry | The page's line | The sheet |
+|---|---|---|
+| Darkvision | *The mines taught our eyes to work where the lamps do not reach.* | nothing |
+| Dwarven Resilience | two wordings, see QST-0116 | nothing |
+| Dwarven Toughness | *A dwarf is built like a ledger: every year adds a line, and none is ever struck out.* | nothing |
+| Stonecunning | *Lay a hand on the stone and listen. The mountain still keeps our accounts.* | nothing |
+
+**2. ~~Stonecunning put the stone contact on the wrong thing.~~ Fixed
+2026-09-12.**
+
+The sheet read *"You must be on a stone surface or touching a stone surface to
+use this **Tremorsense**"*, which a table reads as a condition on keeping the
+sense for its ten minutes rather than on starting it. Ten minutes is a long time
+to hold a wall. The published rule and §0 both put it on the Bonus Action.
+`Dwarves/resolution.py:119` interpolated `Stonecunning.SENSE` where it meant
+`Stonecunning.ACTION`, so the defect was one constant wide. The page names this
+one itself:
+
+> This is a projection to correct in `Dwarves/resolution.py`, not a house rule
+
+**3. ~~`Dwarven_Toughness` published its contribution twice.~~ Fixed
+2026-09-12.**
+
+`Dwarves/traits.py` carried the same eleven lines back to back, comment and all:
+read `bonus_health_sources`, set the Dwarf's key, sum, then do it again. The
+by-name dictionary made it idempotent, so nothing on any sheet was ever wrong,
+which is exactly why it survived. This is the same defect QST-0113 found in
+`Aasimar/resolution.py`, in the same shape, so it is worth saying out loud that
+**a duplicated block in this codebase is a copy-paste signature to grep for after
+a vault restore**, not a coincidence.
+
+## 🧾 Evidence
+
+- `Resolve_Dwarf_Features` on a bare Dwarf, levels 1 and 5: four entries, no
+  italic line in any description, before and after.
+- `bonus_health_sources` is `{'Dwarven Toughness': 1}` before and after the
+  de-duplication, so the removal is provably behaviour-preserving.
+- `python -m AtlasActorLudi.SpeciesKit` cannot run in this checkout: it dies in
+  `AtlasLusoris/Grimoire_of_Guilds.py:34` on `ValueError: bad marshal data`,
+  a version-locked `.pyc` bootstrap, on the Elf path and before the Dwarf. It
+  fails identically on a clean tree. QST-0076's territory, recorded here because
+  it is why the house self-test could not sign this change off.
+
+## 🎯 Desired outcome
+
+1. ~~Stonecunning's stone contact is on the Bonus Action.~~ Landed.
+2. ~~The duplicated block is gone.~~ Landed.
+3. All four lines reach the sheet in the house format, **once Julio has ruled
+   which Resilience line is the line** (QST-0116, item 2). One commit, four
+   strings, no logic.
+
+## 🧭 Notes for the implementer
+
+The wiring is one prefix per entry, exactly as the Aasimar does it:
+
+```python
+	"*Lay a hand on the stone and listen. The mountain still keeps our accounts.*\n\n"
+```
+
+**One thing to decide before writing them, and it is not mechanical.**
+For-Reviewers rule 3 asks for second person and no collective *we*, and three of
+the four lines say *our*: our eyes, our ancestors, our accounts. That is not a
+defect here. The rule reads *"no collective 'we' for a people with no shared
+culture"*, and the Dwarf is the people who most plainly have one: QST-0094
+ratified the species entry's first person plural (*"Dwarves. We remember."*) for
+that reason. But the species entry is the people talking about themselves, and a
+feature line is the project talking to one player about their own body. *The
+mines taught our eyes* puts the reader inside a clan they have not been given
+yet. *The mines taught your eyes to work where the lamps do not reach* costs
+nothing and lands on the person holding the sheet.
+
+Julio's call, and it is the same call for all four at once.


### PR DESCRIPTION
First pass of the Dwarf, run the way the Aasimar was run: every claim read out of the implementation rather than from memory, and a generated Dwarf read back at levels 1 and 5.

**Nothing on `Dwarf.md` was edited.** A book is Julio's. The findings are filed as Questae and the page is untouched.

## Fixed, because the page already names both

- **Stonecunning put the stone contact on the wrong thing.** The sheet read *"you must be on a stone surface or touching a stone surface to use this **Tremorsense**"*, which a table reads as a condition on keeping the sense for its ten minutes rather than on starting it. The published rule and `Dwarf.md` §0 both put it on the Bonus Action, and §0 calls the fix out by file name. One constant wide: `Stonecunning.SENSE` where the rule means `Stonecunning.ACTION`.
- **`Dwarven_Toughness` published its contribution twice**, comment and all. The by-name dictionary made it idempotent, so no sheet was ever wrong, which is exactly why it survived. `bonus_health_sources` is `{'Dwarven Toughness': 1}` before and after, so the removal is provably behaviour-preserving. It is the same duplicate QST-0113 found in `Aasimar/resolution.py`.

## Filed, because they are rulings rather than repairs

| Questa | What it holds |
|---|---|
| **QST-0116** (Open) | Five places where the page contradicts itself, the code, or the locked Aasimar table. §2 writes *"the deepest on the roster"* that §0 forbids and the code disproves; the Resilience line exists in two disagreeing wordings; §3 quotes *Gilded* where the entry says *Guilded*; §2's Aasimar metal list is three short; §0 accuses §8 of an error using a ticket that has since moved. |
| **QST-0117** (Working) | The four authored lines still do not reach the sheet. The Dwarf and the Tiefling are the only playable species printing no voice at all, and the Dwarf's difference is that its lines are written and one commit away. Blocked on QST-0116 item 2. |
| **QST-0118** (Open) | `SpeciesKit/Dwarves.py` is dead and defines a second `Dwarf` with none of the four traits, so an edit there is correct code that changes nothing. `Dwarves/__init__.py.source-partial` is not a copy of the entry but an older second-person draft carrying a sentence the shipping text does not have. |
| **QST-0119** (Open) | Not a Dwarf finding. Darkvision's rule text exists in three wordings, one of them on the locked Aasimar page, and one shared helper serves six species, so no rewording satisfies two locked pages at once. The lock's script checks the description, the lines and the tables, and never a rule, which is where QST-0113's drift actually was. |

## Verification

- `Resolve_Dwarf_Features` projected onto a Dwarf at levels 1 and 5, entries read back before and after.
- Darkvision ranges compared across the roster in code: Dwarf 120, Orc 120, Drow / Dark Elf / Shadow Elf 120. Five ranges tie, so §2's superlative is false.
- `scripts/verify_aasimar_page.py` still passes (ALL CLEAR), unchanged by this branch.
- `python -m AtlasActorLudi.SpeciesKit` **cannot run in this checkout**: it dies in `AtlasLusoris/Grimoire_of_Guilds.py:34` on `ValueError: bad marshal data`, a version-locked `.pyc` bootstrap, on the Elf path and before the Dwarf. It fails identically on a clean tree, so it is pre-existing and QST-0076's territory. It is why the house self-test could not sign this change off, and it is recorded in QST-0117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEHYgGHaf9gKJ1GcMqUWgB

---
_Generated by [Claude Code](https://claude.ai/code/session_01FEHYgGHaf9gKJ1GcMqUWgB)_